### PR TITLE
security: harden GitHub Actions runners across all workflows (#9-16)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,11 @@ jobs:
       matrix:
         node-version: [22]
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+
       - name: Check out repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,6 +33,11 @@ jobs:
             build-mode: none
 
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+
       - name: Checkout repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/codescan.yml
+++ b/.github/workflows/codescan.yml
@@ -18,6 +18,11 @@ jobs:
     name: Trivy Vulnerability Scan
     runs-on: ubuntu-latest
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+
       - name: Checkout repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -24,6 +24,11 @@ jobs:
     timeout-minutes: 15
 
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+
       - name: Check out repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/poll.yml
+++ b/.github/workflows/poll.yml
@@ -24,6 +24,11 @@ jobs:
     timeout-minutes: 4  # Must finish before next cron tick
 
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+
       - name: Check out repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,11 @@ jobs:
         node-version: [22.x]
 
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+
       - name: Checkout code
         uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

- Adds `step-security/harden-runner@v2.16.0` (`egress-policy: audit`) as the first step in all GitHub Actions jobs
- Prevents exfiltration of CI/CD credentials and detects runtime tampering
- Applied to: `ci.yml`, `codeql.yml`, `codescan.yml`, `eslint.yml`, `poll.yml`, `test.yml`

Closes #9, #10, #11, #12, #13, #14, #15, #16

## Test plan
- [ ] Verify each workflow runs without errors after harden-runner is added
- [ ] Confirm StepSecurity audit events appear in the runner dashboard

?? Generated with [Claude Code](https://claude.ai/claude-code)