### PR TITLE
chore(deps): add Dependabot config and harden dependency review

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,101 @@
+# Dependabot configuration
+# Docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+
+updates:
+  # npm (Node.js / TypeScript)
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "javascript"
+    reviewers:
+      - "donny-devops"
+    assignees:
+      - "donny-devops"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+      include: "scope"
+    groups:
+      types:
+        patterns:
+          - "@types/*"
+      eslint:
+        patterns:
+          - "eslint"
+          - "eslint-*"
+          - "@typescript-eslint/*"
+      jest:
+        patterns:
+          - "jest"
+          - "ts-jest"
+          - "@types/jest"
+          - "supertest"
+          - "@types/supertest"
+      production-minor-patch:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      development-minor-patch:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      # Major version bumps for runtime-critical packages should be handled manually.
+      - dependency-name: "express"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "stripe"
+        update-types: ["version-update:semver-major"]
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    reviewers:
+      - "donny-devops"
+    assignees:
+      - "donny-devops"
+    commit-message:
+      prefix: "chore(ci)"
+      include: "scope"
+    groups:
+      actions:
+        patterns:
+          - "*"
+
+  # Docker base images
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "docker"
+    reviewers:
+      - "donny-devops"
+    assignees:
+      - "donny-devops"
+    commit-message:
+      prefix: "chore(docker)"
+      include: "scope"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -20,3 +20,5 @@ jobs:
         uses: actions/dependency-review-action@v4
         with:
           comment-summary-in-pr: always
+          fail-on-severity: high
+          deny-licenses: GPL-2.0, GPL-3.0, AGPL-3.0


### PR DESCRIPTION
## Summary

- Add `.github/dependabot.yml` configuring weekly Monday updates for the three ecosystems present in this repo: **npm**, **github-actions**, and **docker**.
- Group updates to keep PR noise low (TypeScript types, ESLint stack, Jest stack, prod/dev minor+patch).
- Add labels (`dependencies`, plus per-ecosystem), reviewers, and assignees (`donny-devops`).
- Ignore `express` and `stripe` major-version bumps so they are reviewed manually.
- Harden existing `dependency-review.yml` to `fail-on-severity: high` and deny copyleft licenses (GPL-2.0/3.0, AGPL-3.0).

## Why these ecosystems

- `package.json` + `package-lock.json` → npm
- `Dockerfile` (`node:20-alpine` base) → docker
- `.github/workflows/*.yml` → github-actions

## Validation

- YAML parsed locally with `yaml.safe_load` for both `dependabot.yml` and the updated workflow — both OK.
- Schema follows `version: 2` Dependabot conventions and `actions/dependency-review-action@v4` documented inputs.

## Test plan

- [ ] Once merged, confirm Dependabot opens an initial set of PRs (or "no updates" log) for each ecosystem in the Insights → Dependency graph → Dependabot tab.
- [ ] Verify dependency-review status check runs on a subsequent PR and respects the new severity/license thresholds.