### PR TITLE
ci: add consolidated security scanning workflow

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,84 @@
+name: Security Scan
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    - cron: "17 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: security-scan-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  npm-audit:
+    name: npm audit (production deps)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Run npm audit (high severity, production only)
+        run: npm audit --omit=dev --audit-level=high
+
+  osv-scanner:
+    name: OSV-Scanner (lockfile vulnerabilities)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run OSV-Scanner
+        uses: google/osv-scanner-action/osv-scanner-action@v1.9.2
+        with:
+          scan-args: |-
+            --recursive
+            --skip-git
+            --format=sarif
+            --output=osv-results.sarif
+            ./
+        continue-on-error: true
+
+      - name: Upload OSV-Scanner SARIF to GitHub Security
+        if: always() && hashFiles('osv-results.sarif') != ''
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: osv-results.sarif
+          category: osv-scanner
+
+  gitleaks:
+    name: Gitleaks (secret scanning)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: true
+          GITLEAKS_ENABLE_SUMMARY: true


### PR DESCRIPTION
## Summary

Adds `.github/workflows/security-scan.yml` — a consolidated security scanning workflow that complements the existing CodeQL, Trivy, and dependency-review workflows without duplicating them.

Three jobs:
- **npm audit** — runs on production dependencies, fails on high/critical findings
- **OSV-Scanner** — scans lockfiles for known vulnerabilities, uploads SARIF to the Security tab
- **Gitleaks** — scans full git history for leaked secrets

## Triggers

- `pull_request` to `main`
- `push` to `main`
- Weekly schedule (Mondays 06:17 UTC)
- `workflow_dispatch`

## Design choices

- Least-privilege: top-level `permissions: contents: read`; only the OSV job elevates to `security-events: write` for SARIF upload.
- Pinned action versions for safe defaults.
- `concurrency` group cancels superseded runs on the same ref.
- `npm ci --ignore-scripts` to avoid running install scripts during the audit job.
- No external secrets required (uses the default `GITHUB_TOKEN` only).
- Skips duplication: CodeQL (SAST) and Trivy (filesystem CVE) already live in separate workflows.

## Test plan

- [ ] Workflow runs on this PR and the three jobs complete.
- [ ] OSV-Scanner SARIF appears under the Security → Code scanning tab.
- [ ] Gitleaks summary appears in the workflow run.
- [ ] No new permission prompts or missing-secret errors.

## Follow-ups (repo settings)

- Ensure GitHub Advanced Security / code scanning is enabled so SARIF uploads are visible (works on public repos by default).
- Optional: add `GITLEAKS_LICENSE` secret only if the org repo is private and you want PR-comment summaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)