### PR TITLE
chore(deps): address PR #26 review findings (groups, licenses, permissions)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,11 +27,20 @@ updates:
       types:
         patterns:
           - "@types/*"
+        exclude-patterns:
+          - "@types/jest"
+          - "@types/supertest"
+        update-types:
+          - "minor"
+          - "patch"
       eslint:
         patterns:
           - "eslint"
           - "eslint-*"
           - "@typescript-eslint/*"
+        update-types:
+          - "minor"
+          - "patch"
       jest:
         patterns:
           - "jest"
@@ -39,6 +48,9 @@ updates:
           - "@types/jest"
           - "supertest"
           - "@types/supertest"
+        update-types:
+          - "minor"
+          - "patch"
       production-minor-patch:
         dependency-type: "production"
         update-types:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   dependency-review:
@@ -21,4 +22,7 @@ jobs:
         with:
           comment-summary-in-pr: always
           fail-on-severity: high
-          deny-licenses: GPL-2.0, GPL-3.0, AGPL-3.0
+          # Comma-separated SPDX identifiers (no spaces) to avoid parser ambiguity.
+          # Includes legacy IDs (GPL-2.0, GPL-3.0, AGPL-3.0) and modern SPDX
+          # variants (-only / -or-later) so both forms are matched.
+          deny-licenses: "GPL-2.0,GPL-2.0-only,GPL-2.0-or-later,GPL-3.0,GPL-3.0-only,GPL-3.0-or-later,AGPL-3.0,AGPL-3.0-only,AGPL-3.0-or-later"


### PR DESCRIPTION
## Summary

Follow-up to #26. Applies targeted fixes from the automated code reviews on that PR — no behavioral expansion, just corrections.

### `.github/dependabot.yml`
- **Resolve npm group overlap.** `@types/jest` and `@types/supertest` previously matched both the broad `types` group (`@types/*`) and the explicit `jest` group, leaving the resulting grouping order-dependent. Added `exclude-patterns` to the `types` group so those two packages are grouped exclusively with `jest`. The explicit entries in the `jest` group (which were already there) are preserved as the single source of truth.
- **Constrain named groups to non-major updates.** Added `update-types: ["minor", "patch"]` to `types`, `eslint`, and `jest` so major version bumps for those packages get their own PRs instead of being silently bundled into a grouped update.

### `.github/workflows/dependency-review.yml`
- **Fix `deny-licenses` formatting.** The action splits this input on commas, so `"GPL-2.0, GPL-3.0, AGPL-3.0"` is ambiguous because of the leading spaces in each entry. Rewrote as a comma-separated string with no spaces.
- **Include modern SPDX variants.** Added `GPL-2.0-only`, `GPL-2.0-or-later`, `GPL-3.0-only`, `GPL-3.0-or-later`, `AGPL-3.0-only`, `AGPL-3.0-or-later` alongside the legacy `GPL-2.0`, `GPL-3.0`, `AGPL-3.0` identifiers so both the legacy and current SPDX forms are caught.
- **Add `pull-requests: write` permission.** `comment-summary-in-pr: always` posts a summary comment on the PR, which requires write access to pull requests. `contents: read` alone is insufficient.

### Intentionally not changed
- Reviewers / assignees on Dependabot updates — currently useful, no obvious better alternative.
- `ignore` rules — no new package.json signal that warrants additional entries.
- Schedules — no observed pile-up.

## Validation

- `python3 -c "yaml.safe_load(...)"` on both files: OK
- `yamllint` (default rules, line-length/comments/document-start/truthy disabled): no warnings
- Group-overlap audit script: confirms `@types/jest` and `@types/supertest` are excluded from the `types` group and only matched by the `jest` group; all named groups carry `update-types: [minor, patch]`

## Test plan

- [ ] After merge, observe Dependabot rebases existing or queues new grouped PRs without `@types/jest`/`@types/supertest` appearing in the `types` PR.
- [ ] On a future PR, confirm the dependency-review action posts its summary comment (proving `pull-requests: write` is honored).
- [ ] Confirm a denied license (e.g. a dep with `GPL-3.0-or-later`) is now flagged.