### PR TITLE
ci: remove broken stub workflow files

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -1,2 +1,0 @@
-- name: Cache
-  uses: actions/cache@v5.0.4

--- a/.github/workflows/checkout.yml
+++ b/.github/workflows/checkout.yml
@@ -1,2 +1,0 @@
-- name: Checkout
-  uses: actions/checkout@v6.0.2

--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -1,2 +1,0 @@
-- name: Claude Code Action Official
-  uses: anthropics/claude-code-action@v1

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -1,2 +1,0 @@
-- name: Super-Linter
-  uses: super-linter/super-linter@v8.6.0

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -1,2 +1,0 @@
-- name: TruffleHog OSS
-  uses: trufflesecurity/trufflehog@v3.94.2


### PR DESCRIPTION
## Summary

Removes five workflow files in `.github/workflows/` that contained only a single GitHub Actions step fragment with no top-level `name`, `on`, or `jobs` keys. They would fail workflow validation and never executed — they were inert noise on the Actions tab.

| File | Disposition | Reason |
|---|---|---|
| `cache.yml` | Remove | Stub of `actions/cache@v5.0.4`. Caching is already done in `ci.yml`/`eslint.yml` via `actions/setup-node`'s built-in npm cache. |
| `checkout.yml` | Remove | Stub of `actions/checkout@v6.0.2`. Every functional workflow already performs its own checkout. |
| `claude-code.yml` | Remove | Stub of `anthropics/claude-code-action@v1`. Repairing requires an `ANTHROPIC_API_KEY` secret and a defined PR/issue trigger — out of scope here; remove rather than carry a placeholder. |
| `super-linter.yml` | Remove | Stub of `super-linter/super-linter@v8.6.0`. Linting is already covered by `eslint.yml` using the project's own ESLint config and TS-specific tooling. Super-linter would duplicate. |
| `trufflehog.yml` | Remove | Stub of `trufflesecurity/trufflehog@v3.94.2`. Secret scanning is being introduced via Gitleaks in the consolidated security-scan workflow in #29. |

No functional workflow was touched. CodeQL, Trivy (`codescan.yml`), `dependency-review.yml`, the new `security-scan.yml` (#29), `ci.yml`, `eslint.yml`, `test.yml`, `script.yml`, and `poll.yml` are unchanged.

## Validation

- `python -c yaml.safe_load` on every remaining workflow + check for required keys (`name`, `on`, `jobs`, non-empty job map): all 8 pass.
- `actionlint 1.7.7` against `.github/workflows/*.yml`: exit 0, no findings.

## Follow-up recommendations (not in this PR)

- Test workflow consolidation: `ci.yml`, `script.yml`, and `test.yml` all run `npm install`/`npm test` on push+PR. They likely should be merged into one matrixed workflow to cut duplicate CI minutes.
- If the team wants Claude Code Action to actually run on PRs, re-introduce `claude-code.yml` with proper `on:`/`jobs:` structure plus the `ANTHROPIC_API_KEY` secret.

## Test plan

- [ ] CI on this PR passes (`CI`, `ESLint`, `Tests`, `CodeQL`, `Code Scan (Trivy)`, `Dependency review`).
- [ ] No new "invalid workflow file" notices appear on the Actions tab after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)