### PR TITLE
ci(deps): move dependency-review license policy to config file

### DIFF
--- a/.github/dependency-review-config.yml
+++ b/.github/dependency-review-config.yml
@@ -1,0 +1,20 @@
+# Configuration for actions/dependency-review-action@v4
+# Referenced from .github/workflows/dependency-review.yml via the
+# `config-file` input. Keeping policy here (instead of inline in the
+# workflow) makes the license set easier to audit and update.
+
+fail-on-severity: high
+comment-summary-in-pr: always
+
+# Denied licenses. Includes legacy SPDX IDs (GPL-2.0, GPL-3.0, AGPL-3.0)
+# and modern -only / -or-later variants so both forms are matched.
+deny-licenses:
+  - GPL-2.0
+  - GPL-2.0-only
+  - GPL-2.0-or-later
+  - GPL-3.0
+  - GPL-3.0-only
+  - GPL-3.0-or-later
+  - AGPL-3.0
+  - AGPL-3.0-only
+  - AGPL-3.0-or-later

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -20,9 +20,6 @@ jobs:
       - name: Dependency Review
         uses: actions/dependency-review-action@v4
         with:
-          comment-summary-in-pr: always
-          fail-on-severity: high
-          # Comma-separated SPDX identifiers (no spaces) to avoid parser ambiguity.
-          # Includes legacy IDs (GPL-2.0, GPL-3.0, AGPL-3.0) and modern SPDX
-          # variants (-only / -or-later) so both forms are matched.
-          deny-licenses: "GPL-2.0,GPL-2.0-only,GPL-2.0-or-later,GPL-3.0,GPL-3.0-only,GPL-3.0-or-later,AGPL-3.0,AGPL-3.0-only,AGPL-3.0-or-later"
+          # Policy (fail-on-severity, comment-summary-in-pr, deny-licenses)
+          # is defined in .github/dependency-review-config.yml.
+          config-file: .github/dependency-review-config.yml


### PR DESCRIPTION
## Summary

Follow-up to #30. Migrates the `actions/dependency-review-action@v4` license policy out of the inline workflow and into a dedicated config file at `.github/dependency-review-config.yml`, referenced from the workflow via the action's `config-file` input.

License coverage is unchanged. The denied set still covers both legacy SPDX IDs (`GPL-2.0`, `GPL-3.0`, `AGPL-3.0`) and the modern `-only` / `-or-later` variants. `fail-on-severity: high` and `comment-summary-in-pr: always` are preserved (also moved into the config file). Workflow `permissions` (`contents: read`, `pull-requests: write`) are unchanged.

### Files changed
- `.github/dependency-review-config.yml` (new) — holds `fail-on-severity`, `comment-summary-in-pr`, and the `deny-licenses` list.
- `.github/workflows/dependency-review.yml` — drops the inline `with:` policy fields; adds `config-file: .github/dependency-review-config.yml`.

### Policy migration
Inline `deny-licenses` (comma-separated string):
\`\`\`
GPL-2.0,GPL-2.0-only,GPL-2.0-or-later,GPL-3.0,GPL-3.0-only,GPL-3.0-or-later,AGPL-3.0,AGPL-3.0-only,AGPL-3.0-or-later
\`\`\`
becomes a YAML list under `deny-licenses:` in the config file (same nine identifiers).

### Caveats
- Per the dependency-review-action docs, `deny-licenses` is marked deprecated and may be removed in a future release. A future change could switch to an `allow-licenses` allow-list, but that is a policy change (broader behavioral impact) and is intentionally out of scope here.
- `allow-licenses` and `deny-licenses` are mutually exclusive — only `deny-licenses` is set.

## Test plan
- [x] YAML syntax validated locally with `python3 -c 'yaml.safe_load(...)'` for both files.
- [x] Confirmed `config-file` is the supported input on `actions/dependency-review-action@v4`, and `.github/dependency-review-config.yml` is the documented default location.
- [ ] Confirm via a follow-up PR that the action loads the config and applies the deny list (will surface in the PR's own dependency-review check on next dependency change).

---
🤖 *Generated by Computer*