### PR TITLE
fix: resolve remaining test failures from mockResponse capture bug

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -76,13 +76,18 @@ app.use((_req: Request, res: Response) => {
   res.status(404).json({ error: 'Not Found' });
 });
 
-app.use((err: Error, req: Request, res: Response, _next: NextFunction) => {
+app.use((err: Error & { status?: number; statusCode?: number; type?: string }, req: Request, res: Response, _next: NextFunction) => {
   logger.error('Unhandled error', {
     message: err.message,
     stack: err.stack,
     path: req.path,
     method: req.method,
   });
+  const status = err.status ?? err.statusCode;
+  if (typeof status === 'number' && status >= 400 && status < 500) {
+    res.status(status).json({ error: err.message || 'Bad Request' });
+    return;
+  }
   res.status(500).json({ error: 'Internal Server Error' });
 });
 

--- a/tests/unit/github.webhook.test.ts
+++ b/tests/unit/github.webhook.test.ts
@@ -65,12 +65,12 @@ describe('githubWebhookHandler — missing headers', () => {
       body: Buffer.from('{}'),
       headers: { 'x-github-event': 'push' },
     } as unknown as Request;
-    const { res, statusCode, body } = mockResponse();
+    const mock = mockResponse();
 
-    githubWebhookHandler(req, res as Response);
+    githubWebhookHandler(req, mock.res as Response);
 
-    expect(statusCode).toBe(400);
-    expect(body).toMatchObject({ error: expect.stringContaining('Signature') });
+    expect(mock.statusCode).toBe(400);
+    expect(mock.body).toMatchObject({ error: expect.stringContaining('Signature') });
   });
 
   it('returns 400 when X-GitHub-Event is absent', () => {
@@ -79,12 +79,12 @@ describe('githubWebhookHandler — missing headers', () => {
       body: built.body,
       headers: { 'x-hub-signature-256': built.signature },
     } as unknown as Request;
-    const { res, statusCode, body } = mockResponse();
+    const mock = mockResponse();
 
-    githubWebhookHandler(req, res as Response);
+    githubWebhookHandler(req, mock.res as Response);
 
-    expect(statusCode).toBe(400);
-    expect(body).toMatchObject({ error: expect.stringContaining('Event') });
+    expect(mock.statusCode).toBe(400);
+    expect(mock.body).toMatchObject({ error: expect.stringContaining('Event') });
   });
 });
 
@@ -98,12 +98,12 @@ describe('githubWebhookHandler — signature verification', () => {
       { ref: 'refs/heads/main' },
       { signature: 'sha256=deadbeef000000000000000000000000000000000000000000000000000000000000' }
     );
-    const { res, statusCode, body } = mockResponse();
+    const mock = mockResponse();
 
-    githubWebhookHandler(req as Request, res as Response);
+    githubWebhookHandler(req as Request, mock.res as Response);
 
-    expect(statusCode).toBe(401);
-    expect(body).toMatchObject({ error: expect.stringContaining('signature') });
+    expect(mock.statusCode).toBe(401);
+    expect(mock.body).toMatchObject({ error: expect.stringContaining('signature') });
   });
 
   it('returns 401 when signature length mismatches (timing-safe guard)', () => {
@@ -112,11 +112,11 @@ describe('githubWebhookHandler — signature verification', () => {
       { ref: 'refs/heads/main' },
       { signature: 'sha256=short' }
     );
-    const { res, statusCode } = mockResponse();
+    const mock = mockResponse();
 
-    githubWebhookHandler(req as Request, res as Response);
+    githubWebhookHandler(req as Request, mock.res as Response);
 
-    expect(statusCode).toBe(401);
+    expect(mock.statusCode).toBe(401);
   });
 
   it('accepts a correctly signed payload and returns 200', () => {
@@ -126,12 +126,12 @@ describe('githubWebhookHandler — signature verification', () => {
       pusher: { name: 'donny' },
     };
     const req = makeGitHubReq('push', payload);
-    const { res, statusCode, body } = mockResponse();
+    const mock = mockResponse();
 
-    githubWebhookHandler(req as Request, res as Response);
+    githubWebhookHandler(req as Request, mock.res as Response);
 
-    expect(statusCode).toBe(200);
-    expect(body).toMatchObject({ received: true, event: 'push' });
+    expect(mock.statusCode).toBe(200);
+    expect(mock.body).toMatchObject({ received: true, event: 'push' });
   });
 });
 
@@ -144,12 +144,12 @@ describe('githubWebhookHandler — event routing', () => {
 
   it('handles ping event and returns 200', () => {
     const req = makeGitHubReq('ping', { zen: 'Keep it logically awesome.' });
-    const { res, statusCode, body } = mockResponse();
+    const mock = mockResponse();
 
-    githubWebhookHandler(req as Request, res as Response);
+    githubWebhookHandler(req as Request, mock.res as Response);
 
-    expect(statusCode).toBe(200);
-    expect(body).toMatchObject({ received: true, event: 'ping' });
+    expect(mock.statusCode).toBe(200);
+    expect(mock.body).toMatchObject({ received: true, event: 'ping' });
   });
 
   it('handles push event and returns 200', () => {
@@ -159,12 +159,12 @@ describe('githubWebhookHandler — event routing', () => {
       pusher: { name: 'donny' },
     };
     const req = makeGitHubReq('push', payload);
-    const { res, statusCode, body } = mockResponse();
+    const mock = mockResponse();
 
-    githubWebhookHandler(req as Request, res as Response);
+    githubWebhookHandler(req as Request, mock.res as Response);
 
-    expect(statusCode).toBe(200);
-    expect(body).toMatchObject({ received: true, event: 'push' });
+    expect(mock.statusCode).toBe(200);
+    expect(mock.body).toMatchObject({ received: true, event: 'push' });
   });
 
   it('handles pull_request event and returns 200', () => {
@@ -174,11 +174,11 @@ describe('githubWebhookHandler — event routing', () => {
       repository: { full_name: 'donny-devops/test-repo' },
     };
     const req = makeGitHubReq('pull_request', payload);
-    const { res, statusCode } = mockResponse();
+    const mock = mockResponse();
 
-    githubWebhookHandler(req as Request, res as Response);
+    githubWebhookHandler(req as Request, mock.res as Response);
 
-    expect(statusCode).toBe(200);
+    expect(mock.statusCode).toBe(200);
   });
 
   it('handles release event and returns 200', () => {
@@ -188,11 +188,11 @@ describe('githubWebhookHandler — event routing', () => {
       repository: { full_name: 'donny-devops/test-repo' },
     };
     const req = makeGitHubReq('release', payload);
-    const { res, statusCode } = mockResponse();
+    const mock = mockResponse();
 
-    githubWebhookHandler(req as Request, res as Response);
+    githubWebhookHandler(req as Request, mock.res as Response);
 
-    expect(statusCode).toBe(200);
+    expect(mock.statusCode).toBe(200);
   });
 
   it('handles workflow_run event and returns 200', () => {
@@ -201,11 +201,11 @@ describe('githubWebhookHandler — event routing', () => {
       repository: { full_name: 'donny-devops/test-repo' },
     };
     const req = makeGitHubReq('workflow_run', payload);
-    const { res, statusCode } = mockResponse();
+    const mock = mockResponse();
 
-    githubWebhookHandler(req as Request, res as Response);
+    githubWebhookHandler(req as Request, mock.res as Response);
 
-    expect(statusCode).toBe(200);
+    expect(mock.statusCode).toBe(200);
   });
 
   it('handles repository_dispatch event and returns 200', () => {
@@ -214,20 +214,20 @@ describe('githubWebhookHandler — event routing', () => {
       client_payload: { version: '1.2.3' },
     };
     const req = makeGitHubReq('repository_dispatch', payload);
-    const { res, statusCode } = mockResponse();
+    const mock = mockResponse();
 
-    githubWebhookHandler(req as Request, res as Response);
+    githubWebhookHandler(req as Request, mock.res as Response);
 
-    expect(statusCode).toBe(200);
+    expect(mock.statusCode).toBe(200);
   });
 
   it('handles unknown event gracefully and still returns 200', () => {
     const req = makeGitHubReq('star', { action: 'created' });
-    const { res, statusCode } = mockResponse();
+    const mock = mockResponse();
 
-    githubWebhookHandler(req as Request, res as Response);
+    githubWebhookHandler(req as Request, mock.res as Response);
 
-    expect(statusCode).toBe(200);
+    expect(mock.statusCode).toBe(200);
   });
 });
 
@@ -245,11 +245,11 @@ describe('githubWebhookHandler — header normalisation', () => {
         'x-github-delivery': 'test-delivery-array',
       },
     } as unknown as Request;
-    const { res, statusCode } = mockResponse();
+    const mock = mockResponse();
 
-    githubWebhookHandler(req, res as Response);
+    githubWebhookHandler(req, mock.res as Response);
 
-    expect(statusCode).toBe(200);
+    expect(mock.statusCode).toBe(200);
   });
 });
 
@@ -274,13 +274,13 @@ describe('githubWebhookHandler — error handling', () => {
         'x-github-delivery': built.delivery,
       },
     } as unknown as Request;
-    const { res, statusCode } = mockResponse();
+    const mock = mockResponse();
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
 
-    githubWebhookHandler(req, res as Response);
+    githubWebhookHandler(req, mock.res as Response);
 
     // The implementation catches errors in the switch block and returns 500
-    expect([200, 500]).toContain(statusCode); // graceful: may log-only
+    expect([200, 500]).toContain(mock.statusCode); // graceful: may log-only
     errorSpy.mockRestore();
   });
 });

--- a/tests/unit/stripe.webhook.test.ts
+++ b/tests/unit/stripe.webhook.test.ts
@@ -31,14 +31,18 @@ jest.mock('stripe', () => {
   }));
 });
 
-// Set env vars before import
-beforeAll(() => {
-  process.env.STRIPE_SECRET_KEY = STRIPE_TEST_SECRET_KEY;
-  process.env.STRIPE_WEBHOOK_SECRET = STRIPE_TEST_WEBHOOK_SECRET;
-});
+// Set env vars before the module under test is imported. Static `import`
+// statements get hoisted above `beforeAll`, so we set env vars at top level
+// (after the mock is registered above, before the lazy require below).
+process.env.STRIPE_SECRET_KEY = STRIPE_TEST_SECRET_KEY;
+process.env.STRIPE_WEBHOOK_SECRET = STRIPE_TEST_WEBHOOK_SECRET;
 
-// Import handler AFTER mocks are in place
-import { stripeWebhookHandler } from '../../src/webhooks/stripe.webhook';
+// Lazy-require the handler so it picks up the env vars set above
+// instead of the globalSetup placeholders captured at module-load time.
+/* eslint-disable @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports */
+const { stripeWebhookHandler } =
+  require('../../src/webhooks/stripe.webhook') as typeof import('../../src/webhooks/stripe.webhook');
+/* eslint-enable @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports */
 
 // ---------------------------------------------------------------------------
 // Helper: build a mock Request with a raw Buffer body
@@ -66,12 +70,12 @@ describe('stripeWebhookHandler — missing stripe-signature header', () => {
       body: Buffer.from('{}'),
       headers: {},
     } as unknown as Request;
-    const { res, statusCode, body } = mockResponse();
+    const mock = mockResponse();
 
-    stripeWebhookHandler(req, res as Response);
+    stripeWebhookHandler(req, mock.res as Response);
 
-    expect(statusCode).toBe(400);
-    expect(body).toMatchObject({ error: expect.stringContaining('stripe-signature') });
+    expect(mock.statusCode).toBe(400);
+    expect(mock.body).toMatchObject({ error: expect.stringContaining('stripe-signature') });
   });
 });
 
@@ -89,13 +93,13 @@ describe('stripeWebhookHandler — invalid signature', () => {
 
   it('returns 400 when Stripe signature verification fails', () => {
     const req = makeStripeReq('invoice.payment_succeeded', {}, 'bad_signature');
-    const { res, statusCode, body } = mockResponse();
+    const mock = mockResponse();
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
 
-    stripeWebhookHandler(req, res as Response);
+    stripeWebhookHandler(req, mock.res as Response);
 
-    expect(statusCode).toBe(400);
-    expect(body).toMatchObject({
+    expect(mock.statusCode).toBe(400);
+    expect(mock.body).toMatchObject({
       error: expect.stringContaining('signature verification failed'),
     });
     errorSpy.mockRestore();
@@ -160,12 +164,12 @@ describe('stripeWebhookHandler — supported event routing', () => {
       });
 
       const req = makeStripeReq(eventType, dataObject);
-      const { res, statusCode, body } = mockResponse();
+      const mock = mockResponse();
 
-      stripeWebhookHandler(req, res as Response);
+      stripeWebhookHandler(req, mock.res as Response);
 
-      expect(statusCode).toBe(200);
-      expect(body).toMatchObject({ received: true, eventType });
+      expect(mock.statusCode).toBe(200);
+      expect(mock.body).toMatchObject({ received: true, eventType });
     }
   );
 });
@@ -184,12 +188,12 @@ describe('stripeWebhookHandler — unhandled event type', () => {
     });
 
     const req = makeStripeReq('payment_method.attached', {});
-    const { res, statusCode, body } = mockResponse();
+    const mock = mockResponse();
 
-    stripeWebhookHandler(req, res as Response);
+    stripeWebhookHandler(req, mock.res as Response);
 
-    expect(statusCode).toBe(200);
-    expect(body).toMatchObject({ received: true });
+    expect(mock.statusCode).toBe(200);
+    expect(mock.body).toMatchObject({ received: true });
     consoleSpy.mockRestore();
   });
 });
@@ -211,12 +215,12 @@ describe('stripeWebhookHandler — internal handler error', () => {
     });
 
     const req = makeStripeReq('customer.subscription.created', {});
-    const { res, statusCode } = mockResponse();
+    const mock = mockResponse();
 
-    stripeWebhookHandler(req, res as Response);
+    stripeWebhookHandler(req, mock.res as Response);
 
     // Should be caught by the outer try/catch and returned as 500
-    expect([200, 500]).toContain(statusCode);
+    expect([200, 500]).toContain(mock.statusCode);
     errorSpy.mockRestore();
   });
 });
@@ -237,9 +241,9 @@ describe('stripeWebhookHandler — constructEvent arguments', () => {
     });
 
     const req = makeStripeReq(eventType, dataObject);
-    const { res } = mockResponse();
+    const mock = mockResponse();
 
-    stripeWebhookHandler(req, res as Response);
+    stripeWebhookHandler(req, mock.res as Response);
 
     expect(mockConstructEvent).toHaveBeenCalledWith(
       expect.any(Buffer),


### PR DESCRIPTION
## Summary

Follow-up to #47. After the lint/type-check/build baseline cleanup, `npm test` compiled and ran but reported 46 pass / 18 fail / 64 total. This PR addresses the remaining failures.

**Depends on #47** — base branch is `fix/lint-typecheck-baseline`. Once #47 merges, please re-target this PR to `main` (or merge #47 first and this one will fast-forward).

### Root causes fixed

1. **`mockResponse()` capture bug** — Unit tests destructured `statusCode` and `body` as primitives from `mockResponse()` *before* invoking the handler. Because JS captures primitives by value at destructure time, the local variables never reflected what the handler later wrote into the captured object. Fixed by keeping the captured object and accessing `mock.statusCode` / `mock.body` after the handler runs. The helper itself is unchanged so behaviour and shape stay identical for any other callers.

2. **Stripe webhook test env-var ordering** — The test set `STRIPE_WEBHOOK_SECRET` in `beforeAll`, but the static `import` of the handler was hoisted above `beforeAll`, so `webhookSecret` was captured at module-load time from the `globalSetup` placeholder. The `constructEvent` argument assertion failed because the handler was passing the wrong secret. Fixed by setting env vars at top level (after the `jest.mock` registration) and lazy-`require`-ing the handler, matching the pattern already used in `github.webhook.test.ts`.

3. **Global error handler over-mapping** — `src/index.ts` had a catch-all error handler that rewrote every error (including `PayloadTooLargeError`, `entity.parse.failed`, etc.) to 500. The performance test for large-payload rejection expected 400/413/429. Fixed by forwarding `err.status` / `err.statusCode` for 4xx errors and only defaulting to 500 for true server errors.

### Test results

| | Before (PR #47) | After |
| --- | --- | --- |
| Unit | 24 pass / 17 fail | **41 pass** |
| Integration | 14 pass | **14 pass** |
| Performance | 8 pass / 1 fail | **9 pass** |
| **Total** | 46 pass / 18 fail | **64 pass / 0 fail** |

## Test plan

- [x] `npm test` — 64 pass / 0 fail
- [x] `npm run lint` — clean
- [x] `npm run type-check` — clean
- [x] `npm run build` — clean
- [ ] CI policy-enforcement workflow (PR #27) runs green on this branch

## Risks / notes

- The error-handler change widens the response surface: 4xx error bodies now include `err.message`. Body-parser messages like "request entity too large" are safe to expose, but if any future middleware throws a 4xx with sensitive details, that text would leak. Acceptable for the current scope.
- A pre-existing open-handle warning remains: `app.listen()` runs at module import in `src/index.ts`, which keeps a TCP server open during `tests/integration` and `tests/performance`. Not in scope for this PR — fixing it requires splitting `app` from `app.listen()`. Tests use `--forceExit` via Jest CLI or finish cleanly under `npm test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)