### PR TITLE
fix(runtime): repair package manifest and harden app lifecycle/webhooks

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,43 @@
+module.exports = {
+  root: true,
+  env: {
+    es2022: true,
+    node: true,
+    jest: true,
+  },
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module',
+  },
+  plugins: ['@typescript-eslint'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+  ],
+  ignorePatterns: [
+    'dist/',
+    'coverage/',
+    'node_modules/',
+    '*.js',
+  ],
+  rules: {
+    '@typescript-eslint/no-explicit-any': 'error',
+    '@typescript-eslint/no-unused-vars': [
+      'error',
+      {
+        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+      },
+    ],
+  },
+  overrides: [
+    {
+      files: ['tests/**/*.ts'],
+      rules: {
+        '@typescript-eslint/no-explicit-any': 'off',
+        '@typescript-eslint/no-var-requires': 'off',
+      },
+    },
+  ],
+};

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,56 +1,3 @@
-# Dependabot configurationversion: 2
-updates:
-  # -----------------------------
-  # 1. GitHub Actions
-  # -----------------------------
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    groups:
-      actions:
-        patterns:
-          - "*"
-
-  # -----------------------------
-  # 2. Python (pip)
-  # -----------------------------
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    allow:
-      - dependency-type: "direct"
-    groups:
-      python-deps:
-        patterns:
-          - "*"
-    insecure-external-code-execution: "deny"
-
-  # -----------------------------
-  # 3. Docker
-  # -----------------------------
-  - package-ecosystem: "docker"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    groups:
-      docker-images:
-        patterns:
-          - "*"
-
-  # -----------------------------
-  # 4. npm (if frontend exists)
-  # -----------------------------
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    groups:
-      node-packages:
-        patterns:
-          - "*"
-
 # Docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 version: 2
 
@@ -116,9 +63,38 @@ updates:
     ignore:
       # Major version bumps for runtime-critical packages should be handled manually.
       - dependency-name: "express"
-        update-types: ["version-update:semver-major"]
+        update-types:
+          - "version-update:semver-major"
       - dependency-name: "stripe"
-        update-types: ["version-update:semver-major"]
+        update-types:
+          - "version-update:semver-major"
+
+  # Python (pip)
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 5
+    allow:
+      - dependency-type: "direct"
+    labels:
+      - "dependencies"
+      - "python"
+    reviewers:
+      - "donny-devops"
+    assignees:
+      - "donny-devops"
+    commit-message:
+      prefix: "chore(python-deps)"
+      include: "scope"
+    groups:
+      python-deps:
+        patterns:
+          - "*"
+    insecure-external-code-execution: "deny"
 
   # GitHub Actions
   - package-ecosystem: "github-actions"

--- a/.github/workflows/ai-control-plane.yml
+++ b/.github/workflows/ai-control-plane.yml
@@ -1,0 +1,37 @@
+name: AI Control Plane
+
+on:
+  pull_request:
+    paths:
+      - agents/**
+      - config/model-routing.json
+      - mcp/**
+      - scripts/validate-ai-control-plane.mjs
+      - .github/workflows/ai-control-plane.yml
+  push:
+    branches:
+      - main
+    paths:
+      - agents/**
+      - config/model-routing.json
+      - mcp/**
+      - scripts/validate-ai-control-plane.mjs
+
+permissions:
+  contents: read
+
+jobs:
+  validate-ai-control-plane:
+    name: Validate agent, model, and MCP configuration
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Validate AI control plane
+        run: node scripts/validate-ai-control-plane.mjs

--- a/.github/workflows/ai-runbook-artifact.yml
+++ b/.github/workflows/ai-runbook-artifact.yml
@@ -1,0 +1,67 @@
+name: AI Runbook Artifact
+
+on:
+  workflow_dispatch:
+    inputs:
+      incident_type:
+        description: Revenue incident type to prepare for
+        required: true
+        default: webhook-failure
+        type: choice
+        options:
+          - webhook-failure
+          - billing-anomaly
+          - usage-spike
+          - deployment-regression
+
+permissions:
+  contents: read
+
+jobs:
+  generate-runbook-artifact:
+    name: Generate operator runbook artifact
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build runbook markdown
+        shell: bash
+        run: |
+          mkdir -p artifacts
+          cat > artifacts/ai-runbook.md <<'RUNBOOK'
+          # OpenClaw Revenue Engine AI Runbook
+
+          ## Incident Type
+          ${{ inputs.incident_type }}
+
+          ## Agent Chain
+          1. Revenue Operations Agent analyzes the event summary and risk level.
+          2. Compliance Review Agent checks for privacy, payment, and customer-impact risks.
+          3. Human operator reviews any action touching refunds, customer records, or delivery-impacting changes.
+
+          ## Default Model Routing
+          - Low-risk classification: `fast_classifier`
+          - Operational diagnosis: `reasoning_default`
+          - Customer/payment/security impact: `compliance_strict`
+
+          ## Required Evidence
+          - Request ID
+          - Provider event ID
+          - HTTP status and response body
+          - Timestamp
+          - Deployment SHA
+          - Relevant logs with secrets redacted
+
+          ## Hard Guardrails
+          - Do not execute refunds automatically.
+          - Do not expose secrets, customer payment details, or raw provider signatures.
+          - Do not modify customer records without human approval.
+          - Prefer reversible actions first.
+          RUNBOOK
+
+      - name: Upload runbook artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ai-runbook-${{ inputs.incident_type }}
+          path: artifacts/ai-runbook.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         run: npm run lint --if-present
 
       - name: Type check
-        run: npm run typecheck --if-present
+        run: npm run type-check --if-present
 
       - name: Test
         run: npm test --if-present

--- a/.github/workflows/publish-ai-runbook-gist.yml
+++ b/.github/workflows/publish-ai-runbook-gist.yml
@@ -1,0 +1,97 @@
+name: Publish AI Runbook Gist
+
+on:
+  workflow_dispatch:
+    inputs:
+      incident_type:
+        description: Revenue incident type to publish
+        required: true
+        default: webhook-failure
+        type: choice
+        options:
+          - webhook-failure
+          - billing-anomaly
+          - usage-spike
+          - deployment-regression
+      gist_description:
+        description: Gist description
+        required: false
+        default: OpenClaw Revenue Engine AI Runbook
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  publish-gist:
+    name: Publish AI runbook to Gist
+    runs-on: ubuntu-latest
+    if: ${{ secrets.GIST_TOKEN != '' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build runbook payload
+        shell: bash
+        run: |
+          mkdir -p artifacts
+          cat > artifacts/ai-runbook.md <<'RUNBOOK'
+          # OpenClaw Revenue Engine AI Runbook
+
+          ## Incident Type
+          ${{ inputs.incident_type }}
+
+          ## Purpose
+          Operator-facing runbook generated from repository-controlled AI agent manifests, model routing policy, and MCP server inventory.
+
+          ## Agent Chain
+          1. Revenue Operations Agent
+          2. Compliance Review Agent
+          3. Human operator approval for customer, refund, payment, or production-impacting action
+
+          ## Evidence Checklist
+          - request_id
+          - provider_event_id
+          - deployment_sha
+          - error_summary
+          - redacted logs
+          - recommended next action
+
+          ## Guardrails
+          - No automatic refunds.
+          - No customer record mutation without approval.
+          - No raw secrets, signatures, or payment details.
+          - Use reversible remediation first.
+          RUNBOOK
+
+          jq -n \
+            --arg description "${{ inputs.gist_description }}" \
+            --arg content "$(cat artifacts/ai-runbook.md)" \
+            '{description: $description, public: false, files: {"openclaw-ai-runbook.md": {content: $content}}}' \
+            > artifacts/gist-payload.json
+
+      - name: Create private gist
+        env:
+          GIST_TOKEN: ${{ secrets.GIST_TOKEN }}
+        run: |
+          curl -fsS \
+            -H "Authorization: Bearer ${GIST_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/gists \
+            -d @artifacts/gist-payload.json
+
+      - name: Upload local payload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ai-runbook-gist-payload
+          path: artifacts/
+
+  missing-token:
+    name: Explain missing token
+    runs-on: ubuntu-latest
+    if: ${{ secrets.GIST_TOKEN == '' }}
+    steps:
+      - name: Explain skipped publish
+        run: |
+          echo "GIST_TOKEN is not configured. Add a fine-scoped token with gist permission to publish private gists."

--- a/.github/workflows/publish-ai-runbook-gist.yml
+++ b/.github/workflows/publish-ai-runbook-gist.yml
@@ -26,8 +26,19 @@ jobs:
   publish-gist:
     name: Publish AI runbook to Gist
     runs-on: ubuntu-latest
-    if: ${{ secrets.GIST_TOKEN != '' }}
     steps:
+      - name: Detect gist token
+        id: gist-token
+        shell: bash
+        env:
+          GIST_TOKEN: ${{ secrets.GIST_TOKEN }}
+        run: |
+          if [ -n "$GIST_TOKEN" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -71,6 +82,7 @@ jobs:
             > artifacts/gist-payload.json
 
       - name: Create private gist
+        if: steps.gist-token.outputs.available == 'true'
         env:
           GIST_TOKEN: ${{ secrets.GIST_TOKEN }}
         run: |
@@ -81,17 +93,14 @@ jobs:
             https://api.github.com/gists \
             -d @artifacts/gist-payload.json
 
+      - name: Explain missing token
+        if: steps.gist-token.outputs.available == 'false'
+        run: |
+          echo "GIST_TOKEN is not configured. Add a fine-scoped token with gist permission to publish private gists."
+
       - name: Upload local payload artifact
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: ai-runbook-gist-payload
           path: artifacts/
-
-  missing-token:
-    name: Explain missing token
-    runs-on: ubuntu-latest
-    if: ${{ secrets.GIST_TOKEN == '' }}
-    steps:
-      - name: Explain skipped publish
-        run: |
-          echo "GIST_TOKEN is not configured. Add a fine-scoped token with gist permission to publish private gists."

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -16,6 +16,11 @@ jobs:
     name: Super-Linter
     runs-on: ubuntu-latest
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -27,7 +32,7 @@ jobs:
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VALIDATE_ALL_CODEBASE: false
-          # JS/TS already linted by the existing ESLint workflow (eslint.yml)
+          # JS/TS already linted by the existing ESLint workflow (eslint.yml).
           VALIDATE_JAVASCRIPT_ES: false
           VALIDATE_TYPESCRIPT_ES: false
           VALIDATE_JSCPD: false
@@ -37,7 +42,11 @@ jobs:
           # Repo style is single-quote + 2-space indent; do not enforce Prettier defaults.
           VALIDATE_JAVASCRIPT_PRETTIER: false
           VALIDATE_TYPESCRIPT_PRETTIER: false
+          # JSON formatting is owned by repo review; avoid duplicate policy noise here.
+          VALIDATE_JSON_PRETTIER: false
           # Dockerfile/IaC vulnerability scanning is owned by codescan.yml (Trivy).
           VALIDATE_CHECKOV: false
           # Action security scanning is in scope for a separate hardening PR.
           VALIDATE_GITHUB_ACTIONS_ZIZMOR: false
+          # Keep this workflow least-privilege; do not require PR comment writes.
+          ENABLE_GITHUB_PULL_REQUEST_SUMMARY_COMMENT: false

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -15,6 +15,11 @@ jobs:
     name: TruffleHog OSS
     runs-on: ubuntu-latest
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:

--- a/agents/compliance-review-agent.json
+++ b/agents/compliance-review-agent.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": "1.0.0",
+  "agent_id": "compliance_review_agent",
+  "name": "Compliance Review Agent",
+  "description": "Reviews outbound operational summaries and webhook-derived insights for privacy, payment, and security risk before delivery.",
+  "model_profile": "compliance_strict",
+  "allowed_tools": [
+    "scan_for_secrets",
+    "scan_for_pii",
+    "validate_claims",
+    "draft_remediation_notes"
+  ],
+  "inputs": [
+    "candidate_summary",
+    "event_metadata",
+    "delivery_context"
+  ],
+  "outputs": [
+    "approval_status",
+    "blocking_issues",
+    "required_redactions",
+    "revision_notes"
+  ],
+  "guardrails": {
+    "block_secret_exposure": true,
+    "block_payment_data_exposure": true,
+    "block_unverified_financial_claims": true,
+    "require_human_review_for_customer_impact": true
+  },
+  "success_criteria": [
+    "Blocks sensitive data leakage.",
+    "Distinguishes low-risk wording edits from delivery blockers.",
+    "Returns concrete remediation instructions."
+  ]
+}

--- a/agents/revenue-ops-agent.json
+++ b/agents/revenue-ops-agent.json
@@ -1,0 +1,36 @@
+{
+  "schema_version": "1.0.0",
+  "agent_id": "revenue_ops_agent",
+  "name": "Revenue Operations Agent",
+  "description": "Analyzes subscription, invoice, webhook, and usage events to recommend operational actions for the revenue engine.",
+  "model_profile": "reasoning_default",
+  "allowed_tools": [
+    "read_runtime_health",
+    "read_webhook_events",
+    "summarize_billing_anomalies",
+    "draft_operator_runbook"
+  ],
+  "inputs": [
+    "health_status",
+    "webhook_event_summary",
+    "billing_error_summary",
+    "usage_metric_summary"
+  ],
+  "outputs": [
+    "operational_summary",
+    "risk_level",
+    "recommended_actions",
+    "human_review_required"
+  ],
+  "guardrails": {
+    "never_execute_payments": true,
+    "never_modify_customer_records": true,
+    "require_human_review_for_refunds": true,
+    "redact_secrets": true
+  },
+  "success_criteria": [
+    "Classifies billing anomalies with clear severity.",
+    "Preserves uncertainty instead of inventing root causes.",
+    "Suggests reversible next steps before destructive actions."
+  ]
+}

--- a/config/model-routing.json
+++ b/config/model-routing.json
@@ -1,0 +1,40 @@
+{
+  "schema_version": "1.0.0",
+  "default_profile": "reasoning_default",
+  "profiles": {
+    "reasoning_default": {
+      "purpose": "General operational reasoning, anomaly summaries, and runbook drafting.",
+      "preferred_model_family": "reasoning",
+      "temperature": 0.2,
+      "max_output_tokens": 1200,
+      "requires_citations": false,
+      "human_review_required": false
+    },
+    "compliance_strict": {
+      "purpose": "Privacy, payment, security, and external-delivery review.",
+      "preferred_model_family": "reasoning",
+      "temperature": 0,
+      "max_output_tokens": 900,
+      "requires_citations": true,
+      "human_review_required": true
+    },
+    "fast_classifier": {
+      "purpose": "Low-risk event classification and routing.",
+      "preferred_model_family": "small_fast",
+      "temperature": 0,
+      "max_output_tokens": 300,
+      "requires_citations": false,
+      "human_review_required": false
+    }
+  },
+  "routing_rules": [
+    {
+      "match": "refund|chargeback|payment dispute|customer impact",
+      "profile": "compliance_strict"
+    },
+    {
+      "match": "webhook event classification|health check|routing",
+      "profile": "fast_classifier"
+    }
+  ]
+}

--- a/mcp/servers.json
+++ b/mcp/servers.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": "1.0.0",
+  "servers": [
+    {
+      "id": "github_context",
+      "name": "GitHub Context MCP",
+      "transport": "stdio",
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "required_env": ["GITHUB_TOKEN"],
+      "allowed_capabilities": ["repo_read", "issue_read", "pull_request_read"],
+      "blocked_capabilities": ["repo_write", "secret_read", "workflow_write"],
+      "purpose": "Read-only repository context for agent analysis and runbook generation."
+    },
+    {
+      "id": "filesystem_docs",
+      "name": "Filesystem Docs MCP",
+      "transport": "stdio",
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "./docs", "./agents", "./config"],
+      "required_env": [],
+      "allowed_capabilities": ["file_read"],
+      "blocked_capabilities": ["file_write", "secret_read"],
+      "purpose": "Read-only local documentation and agent policy context."
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -2,10 +2,8 @@
   "name": "openclaw-revenue-engine",
   "version": "1.0.0",
   "description": "Self-hosted revenue engine for OpenClaw agents",
-  "main": "dist/index.js",
- "scripts": {
-  "lint": "echo \"No linting configured yet\""
-}
+  "main": "dist/server.js",
+  "scripts": {
     "lint": "eslint . --ext .ts",
     "type-check": "tsc --noEmit",
     "test": "jest",
@@ -16,8 +14,8 @@
     "build": "tsc",
     "prebuild": "npm run clean",
     "clean": "rm -rf dist",
-    "start": "node dist/index.js",
-    "dev": "ts-node src/index.ts"
+    "start": "node dist/server.js",
+    "dev": "ts-node src/server.ts"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/scripts/validate-ai-control-plane.mjs
+++ b/scripts/validate-ai-control-plane.mjs
@@ -1,0 +1,84 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const repoRoot = process.cwd();
+
+function readJson(relativePath) {
+  const fullPath = path.join(repoRoot, relativePath);
+  try {
+    return JSON.parse(fs.readFileSync(fullPath, 'utf8'));
+  } catch (error) {
+    throw new Error(`Failed to read valid JSON from ${relativePath}: ${error.message}`);
+  }
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function validateAgent(relativePath) {
+  const agent = readJson(relativePath);
+  assert(agent.schema_version, `${relativePath}: schema_version is required`);
+  assert(agent.agent_id, `${relativePath}: agent_id is required`);
+  assert(agent.name, `${relativePath}: name is required`);
+  assert(agent.model_profile, `${relativePath}: model_profile is required`);
+  assert(Array.isArray(agent.allowed_tools), `${relativePath}: allowed_tools must be an array`);
+  assert(Array.isArray(agent.inputs), `${relativePath}: inputs must be an array`);
+  assert(Array.isArray(agent.outputs), `${relativePath}: outputs must be an array`);
+  assert(agent.guardrails && typeof agent.guardrails === 'object', `${relativePath}: guardrails object is required`);
+  return agent;
+}
+
+function validateModelRouting(agents) {
+  const routing = readJson('config/model-routing.json');
+  assert(routing.default_profile, 'config/model-routing.json: default_profile is required');
+  assert(routing.profiles && typeof routing.profiles === 'object', 'config/model-routing.json: profiles object is required');
+  assert(routing.profiles[routing.default_profile], 'config/model-routing.json: default_profile must exist in profiles');
+
+  for (const agent of agents) {
+    assert(
+      routing.profiles[agent.model_profile],
+      `Agent ${agent.agent_id} references missing model profile ${agent.model_profile}`,
+    );
+  }
+}
+
+function validateMcpServers() {
+  const inventory = readJson('mcp/servers.json');
+  assert(Array.isArray(inventory.servers), 'mcp/servers.json: servers must be an array');
+
+  const ids = new Set();
+  for (const server of inventory.servers) {
+    assert(server.id, 'mcp/servers.json: server.id is required');
+    assert(!ids.has(server.id), `mcp/servers.json: duplicate server id ${server.id}`);
+    ids.add(server.id);
+    assert(server.transport, `${server.id}: transport is required`);
+    assert(server.command, `${server.id}: command is required`);
+    assert(Array.isArray(server.allowed_capabilities), `${server.id}: allowed_capabilities must be an array`);
+    assert(Array.isArray(server.blocked_capabilities), `${server.id}: blocked_capabilities must be an array`);
+    assert(
+      server.blocked_capabilities.includes('secret_read'),
+      `${server.id}: blocked_capabilities must include secret_read`,
+    );
+  }
+}
+
+function main() {
+  const agentFiles = fs
+    .readdirSync(path.join(repoRoot, 'agents'))
+    .filter((file) => file.endsWith('.json'))
+    .map((file) => `agents/${file}`)
+    .sort();
+
+  assert(agentFiles.length > 0, 'At least one agent manifest is required');
+
+  const agents = agentFiles.map(validateAgent);
+  validateModelRouting(agents);
+  validateMcpServers();
+
+  console.log(`Validated ${agents.length} agent manifest(s), model routing, and MCP inventory.`);
+}
+
+main();

--- a/src/agents/auditLog.ts
+++ b/src/agents/auditLog.ts
@@ -1,0 +1,59 @@
+import { AgentRunInput, AgentRunResult } from './types';
+
+export interface AgentAuditRecord {
+  request_id: string;
+  agent_id: string;
+  agent_name: string;
+  model_profile: string;
+  risk_level: AgentRunResult['risk_level'];
+  status: AgentRunResult['status'];
+  human_review_required: boolean;
+  findings_count: number;
+  redactions_count: number;
+  mcp_plan_steps: number;
+  objective: string;
+  event_summary?: string;
+  created_at: string;
+  result: AgentRunResult;
+}
+
+const MAX_AUDIT_RECORDS = 500;
+const auditRecords: AgentAuditRecord[] = [];
+
+export function recordAgentRun(input: AgentRunInput, result: AgentRunResult): AgentAuditRecord {
+  const record: AgentAuditRecord = {
+    request_id: result.request_id,
+    agent_id: result.agent_id,
+    agent_name: result.agent_name,
+    model_profile: result.model_profile,
+    risk_level: result.risk_level,
+    status: result.status,
+    human_review_required: result.human_review_required,
+    findings_count: result.findings.length,
+    redactions_count: result.redactions.length,
+    mcp_plan_steps: result.mcp_plan.length,
+    objective: input.objective,
+    event_summary: input.event_summary,
+    created_at: new Date().toISOString(),
+    result,
+  };
+
+  auditRecords.unshift(record);
+  if (auditRecords.length > MAX_AUDIT_RECORDS) {
+    auditRecords.length = MAX_AUDIT_RECORDS;
+  }
+
+  return record;
+}
+
+export function listAgentRuns(limit = 50): AgentAuditRecord[] {
+  return auditRecords.slice(0, Math.max(0, Math.min(limit, MAX_AUDIT_RECORDS)));
+}
+
+export function getAgentRun(requestId: string): AgentAuditRecord | undefined {
+  return auditRecords.find((record) => record.request_id === requestId);
+}
+
+export function clearAgentAuditLogForTests(): void {
+  auditRecords.length = 0;
+}

--- a/src/agents/guardrails.ts
+++ b/src/agents/guardrails.ts
@@ -1,0 +1,39 @@
+import { AgentRunInput, GuardrailFinding, RiskLevel } from './types';
+
+const SECRET_PATTERN = /(api[_-]?key|secret|token|password|whsec_|sk_live_|sk_test_)/i;
+const PAYMENT_PATTERN = /(card number|cvv|cvc|payment method|bank account|chargeback|refund)/i;
+const CUSTOMER_IMPACT_PATTERN = /(delete customer|modify customer|cancel subscription|refund|downgrade|customer impact)/i;
+
+function finding(rule_id: string, severity: RiskLevel, message: string): GuardrailFinding {
+  return { rule_id, severity, message };
+}
+
+export function evaluateGuardrails(input: AgentRunInput): { findings: GuardrailFinding[]; redactedText: string; redactions: string[] } {
+  const text = [input.objective, input.event_summary, JSON.stringify(input.context ?? {})].join('\n');
+  const findings: GuardrailFinding[] = [];
+  const redactions: string[] = [];
+  let redactedText = text;
+
+  if (SECRET_PATTERN.test(text)) {
+    findings.push(finding('secret_exposure', 'critical', 'Potential secret or credential reference detected.'));
+    redactedText = redactedText.replace(SECRET_PATTERN, '[REDACTED_SECRET]');
+    redactions.push('secret_like_value');
+  }
+
+  if (PAYMENT_PATTERN.test(text)) {
+    findings.push(finding('payment_risk', 'high', 'Payment, refund, or card-related language requires review.'));
+  }
+
+  if (CUSTOMER_IMPACT_PATTERN.test(text)) {
+    findings.push(finding('customer_impact', 'high', 'Customer-impacting action requires human approval.'));
+  }
+
+  return { findings, redactedText, redactions };
+}
+
+export function highestRisk(findings: GuardrailFinding[]): RiskLevel {
+  if (findings.some((item) => item.severity === 'critical')) return 'critical';
+  if (findings.some((item) => item.severity === 'high')) return 'high';
+  if (findings.some((item) => item.severity === 'medium')) return 'medium';
+  return 'low';
+}

--- a/src/agents/modelRouter.ts
+++ b/src/agents/modelRouter.ts
@@ -1,0 +1,34 @@
+import { ModelProfile, ModelRoutingPolicy } from './types';
+
+export interface SelectedModelProfile {
+  profile_id: string;
+  profile: ModelProfile;
+  matched_rule?: string;
+}
+
+export function selectModelProfile(
+  objective: string,
+  policy: ModelRoutingPolicy,
+  fallbackProfile?: string,
+): SelectedModelProfile {
+  const normalized = objective.toLowerCase();
+
+  for (const rule of policy.routing_rules) {
+    const pattern = new RegExp(rule.match, 'i');
+    if (pattern.test(normalized)) {
+      const profile = policy.profiles[rule.profile];
+      if (!profile) {
+        throw new Error(`Model routing rule references missing profile: ${rule.profile}`);
+      }
+      return { profile_id: rule.profile, profile, matched_rule: rule.match };
+    }
+  }
+
+  const profileId = fallbackProfile ?? policy.default_profile;
+  const profile = policy.profiles[profileId];
+  if (!profile) {
+    throw new Error(`Missing model profile: ${profileId}`);
+  }
+
+  return { profile_id: profileId, profile };
+}

--- a/src/agents/registry.ts
+++ b/src/agents/registry.ts
@@ -1,0 +1,48 @@
+import fs from 'fs';
+import path from 'path';
+
+import { AgentManifest, ModelRoutingPolicy } from './types';
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+
+function readJson<T>(filePath: string): T {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8')) as T;
+}
+
+function assertManifest(value: AgentManifest): AgentManifest {
+  if (!value.agent_id || !value.name || !value.model_profile) {
+    throw new Error('Invalid agent manifest: agent_id, name, and model_profile are required');
+  }
+  if (!Array.isArray(value.allowed_tools) || !Array.isArray(value.inputs) || !Array.isArray(value.outputs)) {
+    throw new Error(`Invalid agent manifest ${value.agent_id}: allowed_tools, inputs, and outputs must be arrays`);
+  }
+  return value;
+}
+
+export function loadAgentManifests(agentDir = path.join(repoRoot, 'agents')): AgentManifest[] {
+  if (!fs.existsSync(agentDir)) return [];
+
+  return fs
+    .readdirSync(agentDir)
+    .filter((file) => file.endsWith('.json'))
+    .sort()
+    .map((file) => assertManifest(readJson<AgentManifest>(path.join(agentDir, file))));
+}
+
+export function loadAgentManifest(agentId: string): AgentManifest {
+  const manifest = loadAgentManifests().find((agent) => agent.agent_id === agentId);
+  if (!manifest) {
+    throw new Error(`Unknown agent_id: ${agentId}`);
+  }
+  return manifest;
+}
+
+export function loadModelRoutingPolicy(
+  policyPath = path.join(repoRoot, 'config', 'model-routing.json'),
+): ModelRoutingPolicy {
+  const policy = readJson<ModelRoutingPolicy>(policyPath);
+  if (!policy.default_profile || !policy.profiles?.[policy.default_profile]) {
+    throw new Error('Invalid model routing policy: default_profile must exist in profiles');
+  }
+  return policy;
+}

--- a/src/agents/runner.ts
+++ b/src/agents/runner.ts
@@ -1,5 +1,6 @@
 import crypto from 'crypto';
 
+import { planMcpUsage } from '../mcp/planner';
 import { evaluateGuardrails, highestRisk } from './guardrails';
 import { selectModelProfile } from './modelRouter';
 import { loadAgentManifest, loadAgentManifests, loadModelRoutingPolicy } from './registry';
@@ -34,6 +35,7 @@ export function listAgents() {
     description: agent.description,
     model_profile: agent.model_profile,
     allowed_tools: agent.allowed_tools,
+    mcp_plan: planMcpUsage(agent),
   }));
 }
 
@@ -54,6 +56,7 @@ export function runAgent(input: AgentRunInput): AgentRunResult {
     risk === 'critical';
 
   const recommendedActions = buildActions(manifest.agent_id, risk);
+  const mcpPlan = planMcpUsage(manifest);
 
   return {
     request_id: input.request_id ?? crypto.randomUUID(),
@@ -66,11 +69,13 @@ export function runAgent(input: AgentRunInput): AgentRunResult {
     recommended_actions: recommendedActions,
     findings: guardrail.findings,
     redactions: guardrail.redactions,
+    mcp_plan: mcpPlan,
     human_review_required: humanReviewRequired,
     telemetry: {
       input_chars: JSON.stringify(input).length,
       output_actions: recommendedActions.length,
       guardrail_findings: guardrail.findings.length,
+      mcp_plan_steps: mcpPlan.length,
     },
   };
 }

--- a/src/agents/runner.ts
+++ b/src/agents/runner.ts
@@ -1,0 +1,76 @@
+import crypto from 'crypto';
+
+import { evaluateGuardrails, highestRisk } from './guardrails';
+import { selectModelProfile } from './modelRouter';
+import { loadAgentManifest, loadAgentManifests, loadModelRoutingPolicy } from './registry';
+import { AgentRunInput, AgentRunResult, AgentStatus } from './types';
+
+function buildActions(agentId: string, risk: string): string[] {
+  if (agentId === 'compliance_review_agent') {
+    return risk === 'low'
+      ? ['Approve low-risk internal summary.', 'Keep delivery logs for audit traceability.']
+      : ['Block external delivery until findings are remediated.', 'Escalate to a human reviewer.'];
+  }
+
+  return risk === 'low'
+    ? ['Summarize webhook or billing signal.', 'Check recent deployment and provider status.', 'Prepare reversible remediation steps.']
+    : ['Pause destructive action.', 'Collect provider event IDs and request IDs.', 'Route to Compliance Review Agent.'];
+}
+
+function buildSummary(agentName: string, objective: string, risk: string): string {
+  return `${agentName} evaluated the request as ${risk} risk: ${objective}`;
+}
+
+function statusFor(reviewRequired: boolean, findingsCount: number): AgentStatus {
+  if (reviewRequired) return 'requires_human_review';
+  if (findingsCount > 0) return 'blocked';
+  return 'completed';
+}
+
+export function listAgents() {
+  return loadAgentManifests().map((agent) => ({
+    agent_id: agent.agent_id,
+    name: agent.name,
+    description: agent.description,
+    model_profile: agent.model_profile,
+    allowed_tools: agent.allowed_tools,
+  }));
+}
+
+export function runAgent(input: AgentRunInput): AgentRunResult {
+  const manifest = loadAgentManifest(input.agent_id);
+  const policy = loadModelRoutingPolicy();
+  const selectedProfile = selectModelProfile(input.objective, policy, manifest.model_profile);
+  const guardrail = evaluateGuardrails(input);
+  const risk = highestRisk(guardrail.findings);
+  const modelRequiresReview = selectedProfile.profile.human_review_required;
+  const manifestRequiresReview = Boolean(
+    manifest.guardrails.require_human_review_for_refunds
+      || manifest.guardrails.require_human_review_for_customer_impact,
+  );
+  const humanReviewRequired =
+    modelRequiresReview ||
+    (manifestRequiresReview && risk !== 'low') ||
+    risk === 'critical';
+
+  const recommendedActions = buildActions(manifest.agent_id, risk);
+
+  return {
+    request_id: input.request_id ?? crypto.randomUUID(),
+    agent_id: manifest.agent_id,
+    agent_name: manifest.name,
+    model_profile: selectedProfile.profile_id,
+    status: statusFor(humanReviewRequired, guardrail.findings.length),
+    risk_level: risk,
+    summary: buildSummary(manifest.name, guardrail.redactedText.split('\n')[0], risk),
+    recommended_actions: recommendedActions,
+    findings: guardrail.findings,
+    redactions: guardrail.redactions,
+    human_review_required: humanReviewRequired,
+    telemetry: {
+      input_chars: JSON.stringify(input).length,
+      output_actions: recommendedActions.length,
+      guardrail_findings: guardrail.findings.length,
+    },
+  };
+}

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -49,6 +49,15 @@ export interface GuardrailFinding {
   message: string;
 }
 
+export interface AgentMcpUsagePlan {
+  server_id: string;
+  server_name: string;
+  capability: string;
+  purpose: string;
+  safe_to_execute: boolean;
+  blocked_reason?: string;
+}
+
 export interface AgentRunResult {
   request_id: string;
   agent_id: string;
@@ -60,10 +69,12 @@ export interface AgentRunResult {
   recommended_actions: string[];
   findings: GuardrailFinding[];
   redactions: string[];
+  mcp_plan: AgentMcpUsagePlan[];
   human_review_required: boolean;
   telemetry: {
     input_chars: number;
     output_actions: number;
     guardrail_findings: number;
+    mcp_plan_steps: number;
   };
 }

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -1,0 +1,69 @@
+export type RiskLevel = 'low' | 'medium' | 'high' | 'critical';
+export type AgentStatus = 'completed' | 'blocked' | 'requires_human_review';
+
+export interface AgentManifest {
+  schema_version: string;
+  agent_id: string;
+  name: string;
+  description: string;
+  model_profile: string;
+  allowed_tools: string[];
+  inputs: string[];
+  outputs: string[];
+  guardrails: Record<string, boolean>;
+  success_criteria: string[];
+}
+
+export interface ModelProfile {
+  purpose: string;
+  preferred_model_family: string;
+  temperature: number;
+  max_output_tokens: number;
+  requires_citations: boolean;
+  human_review_required: boolean;
+}
+
+export interface ModelRoutingRule {
+  match: string;
+  profile: string;
+}
+
+export interface ModelRoutingPolicy {
+  schema_version: string;
+  default_profile: string;
+  profiles: Record<string, ModelProfile>;
+  routing_rules: ModelRoutingRule[];
+}
+
+export interface AgentRunInput {
+  request_id?: string;
+  agent_id: string;
+  objective: string;
+  context?: Record<string, unknown>;
+  event_summary?: string;
+}
+
+export interface GuardrailFinding {
+  rule_id: string;
+  severity: RiskLevel;
+  message: string;
+}
+
+export interface AgentRunResult {
+  request_id: string;
+  agent_id: string;
+  agent_name: string;
+  model_profile: string;
+  status: AgentStatus;
+  risk_level: RiskLevel;
+  summary: string;
+  recommended_actions: string[];
+  findings: GuardrailFinding[];
+  redactions: string[];
+  human_review_required: boolean;
+  telemetry: {
+    input_chars: number;
+    output_actions: number;
+    guardrail_findings: number;
+  };
+}

--- a/src/config/app.ts
+++ b/src/config/app.ts
@@ -4,8 +4,8 @@ function parsePort(value: string | undefined, fallback: number): number {
   if (!value) return fallback;
 
   const port = Number.parseInt(value, 10);
-  if (!Number.isInteger(port) || port < 1 || port > 65_535) {
-    throw new Error(`PORT must be an integer between 1 and 65535, got ${value}`);
+  if (!Number.isInteger(port) || port < 0 || port > 65_535) {
+    throw new Error(`PORT must be an integer between 0 and 65535, got ${value}`);
   }
 
   return port;

--- a/src/config/app.ts
+++ b/src/config/app.ts
@@ -1,0 +1,68 @@
+import { getOptionalEnv } from './env';
+
+function parsePort(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+
+  const port = Number.parseInt(value, 10);
+  if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+    throw new Error(`PORT must be an integer between 1 and 65535, got ${value}`);
+  }
+
+  return port;
+}
+
+function parseBoolean(value: string | undefined, fallback = false): boolean {
+  if (value === undefined) return fallback;
+  return value.toLowerCase() === 'true';
+}
+
+function parsePositiveInteger(value: string | undefined, fallback: number, name: string): number {
+  if (!value) return fallback;
+
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new Error(`${name} must be a positive integer, got ${value}`);
+  }
+
+  return parsed;
+}
+
+export interface AppConfig {
+  serviceName: string;
+  version: string;
+  nodeEnv: string;
+  port: number;
+  logLevel: string;
+  corsOrigin: string;
+  corsCredentials: boolean;
+  jsonBodyLimit: string;
+  globalRateLimit: {
+    windowMs: number;
+    max: number;
+  };
+  webhookRateLimit: {
+    windowMs: number;
+    max: number;
+  };
+}
+
+export function loadAppConfig(): AppConfig {
+  return {
+    serviceName: getOptionalEnv('SERVICE_NAME', 'openclaw-revenue-engine') ?? 'openclaw-revenue-engine',
+    version: getOptionalEnv('npm_package_version', '1.0.0') ?? '1.0.0',
+    nodeEnv: getOptionalEnv('NODE_ENV', 'development') ?? 'development',
+    port: parsePort(process.env.PORT, 3000),
+    logLevel: getOptionalEnv('LOG_LEVEL', 'info') ?? 'info',
+    corsOrigin: getOptionalEnv('CORS_ORIGIN', 'http://localhost:3000') ?? 'http://localhost:3000',
+    corsCredentials: parseBoolean(process.env.CORS_CREDENTIALS),
+    jsonBodyLimit: getOptionalEnv('JSON_BODY_LIMIT', '1mb') ?? '1mb',
+    globalRateLimit: {
+      windowMs: parsePositiveInteger(process.env.GLOBAL_RATE_LIMIT_WINDOW_MS, 60_000, 'GLOBAL_RATE_LIMIT_WINDOW_MS'),
+      max: parsePositiveInteger(process.env.GLOBAL_RATE_LIMIT_MAX, 100, 'GLOBAL_RATE_LIMIT_MAX'),
+    },
+    webhookRateLimit: {
+      windowMs: parsePositiveInteger(process.env.WEBHOOK_RATE_LIMIT_WINDOW_MS, 60_000, 'WEBHOOK_RATE_LIMIT_WINDOW_MS'),
+      max: parsePositiveInteger(process.env.WEBHOOK_RATE_LIMIT_MAX, 30, 'WEBHOOK_RATE_LIMIT_MAX'),
+    },
+  };
+}

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,0 +1,21 @@
+const REQUIRED_ENV_ERROR_PREFIX = 'Missing required environment variable:';
+
+export function getRequiredEnv(key: string): string {
+  const value = process.env[key];
+  if (!value) {
+    throw new Error(`${REQUIRED_ENV_ERROR_PREFIX} ${key}`);
+  }
+  return value;
+}
+
+export function getOptionalEnv(key: string, fallback?: string): string | undefined {
+  return process.env[key] ?? fallback;
+}
+
+export function isMissingRequiredEnvError(error: unknown): boolean {
+  return error instanceof Error && error.message.startsWith(REQUIRED_ENV_ERROR_PREFIX);
+}
+
+export function toErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : 'Unknown error';
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import helmet from 'helmet';
 import { createLogger, format, transports } from 'winston';
 
 import { loadAppConfig } from './config/app';
+import { agentsRouter } from './routes/agents';
 import { githubWebhookHandler } from './webhooks/github.webhook';
 import { stripeWebhookHandler } from './webhooks/stripe.webhook';
 
@@ -73,6 +74,7 @@ function createApp(config = appConfig): Application {
     })
   );
   app.use(express.json({ limit: config.jsonBodyLimit }));
+  app.use('/agents', agentsRouter);
 
   app.get('/health', (_req: Request, res: Response) => {
     res.json({
@@ -90,6 +92,7 @@ function createApp(config = appConfig): Application {
       dependencies: {
         stripeWebhook: 'lazy-configured',
         githubWebhook: 'lazy-configured',
+        agents: 'enabled',
       },
     });
   });
@@ -100,6 +103,7 @@ function createApp(config = appConfig): Application {
       version: config.version,
       docs: '/health',
       readiness: '/ready',
+      agents: '/agents',
     });
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,91 +19,92 @@ const logger = createLogger({
   transports: [new transports.Console()],
 });
 
-const app: Application = express();
-const PORT = process.env.PORT ?? 3000;
+function createApp(): Application {
+  const app: Application = express();
 
-const globalLimiter = rateLimit({
-  windowMs: 60_000,
-  max: 100,
-  standardHeaders: true,
-  legacyHeaders: false,
-  message: { error: 'Too many requests, please try again later.' },
-});
-
-const webhookLimiter = rateLimit({
-  windowMs: 60_000,
-  max: 30,
-  standardHeaders: true,
-  legacyHeaders: false,
-  message: { error: 'Too many webhook requests.' },
-});
-
-app.post(
-  '/webhooks/stripe',
-  webhookLimiter,
-  express.raw({ type: 'application/json', limit: '1mb' }),
-  stripeWebhookHandler
-);
-
-app.post(
-  '/webhooks/github',
-  webhookLimiter,
-  express.raw({ type: 'application/json', limit: '1mb' }),
-  githubWebhookHandler
-);
-
-app.use(globalLimiter);
-app.use(helmet());
-app.use(cors({
-  origin: process.env.CORS_ORIGIN ?? 'http://localhost:3000',
-  credentials: process.env.CORS_CREDENTIALS === 'true',
-}));
-app.use(express.json());
-
-app.get('/health', (_req: Request, res: Response) => {
-  res.json({ status: 'ok', timestamp: new Date().toISOString() });
-});
-
-app.get('/', (_req: Request, res: Response) => {
-  res.json({
-    name: 'openclaw-revenue-engine',
-    version: process.env.npm_package_version ?? '1.0.0',
-    docs: '/health',
-  });
-});
-
-app.use((_req: Request, res: Response) => {
-  res.status(404).json({ error: 'Not Found' });
-});
-
-app.use((err: Error, req: Request, res: Response, _next: NextFunction) => {
-  const status =
-    (err as { status?: number; statusCode?: number }).status ??
-    (err as { status?: number; statusCode?: number }).statusCode ??
-    500;
-
-  logger.error('Unhandled error', {
-    message: err.message,
-    stack: err.stack,
-    path: req.path,
-    method: req.method,
-    status,
+  const globalLimiter = rateLimit({
+    windowMs: 60_000,
+    max: 100,
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: { error: 'Too many requests, please try again later.' },
   });
 
-  if (status === 413) {
-    res.status(413).json({ error: 'Payload Too Large' });
-    return;
-  }
-  if (status >= 400 && status < 500) {
-    res.status(status).json({ error: err.message || 'Bad Request' });
-    return;
-  }
-  res.status(500).json({ error: 'Internal Server Error' });
-});
+  const webhookLimiter = rateLimit({
+    windowMs: 60_000,
+    max: 30,
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: { error: 'Too many webhook requests.' },
+  });
 
-app.listen(PORT, () => {
-  logger.info(`[openclaw-revenue-engine] Listening on port ${PORT}`);
-});
+  app.post(
+    '/webhooks/stripe',
+    webhookLimiter,
+    express.raw({ type: 'application/json', limit: '1mb' }),
+    stripeWebhookHandler
+  );
 
-export { logger };
+  app.post(
+    '/webhooks/github',
+    webhookLimiter,
+    express.raw({ type: 'application/json', limit: '1mb' }),
+    githubWebhookHandler
+  );
+
+  app.use(globalLimiter);
+  app.use(helmet());
+  app.use(cors({
+    origin: process.env.CORS_ORIGIN ?? 'http://localhost:3000',
+    credentials: process.env.CORS_CREDENTIALS === 'true',
+  }));
+  app.use(express.json());
+
+  app.get('/health', (_req: Request, res: Response) => {
+    res.json({ status: 'ok', timestamp: new Date().toISOString() });
+  });
+
+  app.get('/', (_req: Request, res: Response) => {
+    res.json({
+      name: 'openclaw-revenue-engine',
+      version: process.env.npm_package_version ?? '1.0.0',
+      docs: '/health',
+    });
+  });
+
+  app.use((_req: Request, res: Response) => {
+    res.status(404).json({ error: 'Not Found' });
+  });
+
+  app.use((err: Error, req: Request, res: Response, _next: NextFunction) => {
+    const status =
+      (err as { status?: number; statusCode?: number }).status ??
+      (err as { status?: number; statusCode?: number }).statusCode ??
+      500;
+
+    logger.error('Unhandled error', {
+      message: err.message,
+      stack: err.stack,
+      path: req.path,
+      method: req.method,
+      status,
+    });
+
+    if (status === 413) {
+      res.status(413).json({ error: 'Payload Too Large' });
+      return;
+    }
+    if (status >= 400 && status < 500) {
+      res.status(status).json({ error: err.message || 'Bad Request' });
+      return;
+    }
+    res.status(500).json({ error: 'Internal Server Error' });
+  });
+
+  return app;
+}
+
+const app = createApp();
+
+export { createApp, logger };
 export default app;

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { createLogger, format, transports } from 'winston';
 import { loadAppConfig } from './config/app';
 import { agentsRouter } from './routes/agents';
 import { mcpRouter } from './routes/mcp';
+import { reviewsRouter } from './routes/reviews';
 import { githubWebhookHandler } from './webhooks/github.webhook';
 import { stripeWebhookHandler } from './webhooks/stripe.webhook';
 
@@ -77,6 +78,7 @@ function createApp(config = appConfig): Application {
   app.use(express.json({ limit: config.jsonBodyLimit }));
   app.use('/agents', agentsRouter);
   app.use('/mcp', mcpRouter);
+  app.use('/reviews', reviewsRouter);
 
   app.get('/health', (_req: Request, res: Response) => {
     res.json({
@@ -96,6 +98,7 @@ function createApp(config = appConfig): Application {
         githubWebhook: 'lazy-configured',
         agents: 'enabled',
         mcp: 'inventory-only',
+        reviews: 'enabled',
       },
     });
   });
@@ -108,6 +111,7 @@ function createApp(config = appConfig): Application {
       readiness: '/ready',
       agents: '/agents',
       mcp: '/mcp/servers',
+      reviews: '/reviews',
     });
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { createLogger, format, transports } from 'winston';
 
 import { loadAppConfig } from './config/app';
 import { agentsRouter } from './routes/agents';
+import { mcpRouter } from './routes/mcp';
 import { githubWebhookHandler } from './webhooks/github.webhook';
 import { stripeWebhookHandler } from './webhooks/stripe.webhook';
 
@@ -75,6 +76,7 @@ function createApp(config = appConfig): Application {
   );
   app.use(express.json({ limit: config.jsonBodyLimit }));
   app.use('/agents', agentsRouter);
+  app.use('/mcp', mcpRouter);
 
   app.get('/health', (_req: Request, res: Response) => {
     res.json({
@@ -93,6 +95,7 @@ function createApp(config = appConfig): Application {
         stripeWebhook: 'lazy-configured',
         githubWebhook: 'lazy-configured',
         agents: 'enabled',
+        mcp: 'inventory-only',
       },
     });
   });
@@ -104,6 +107,7 @@ function createApp(config = appConfig): Application {
       docs: '/health',
       readiness: '/ready',
       agents: '/agents',
+      mcp: '/mcp/servers',
     });
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,79 +1,110 @@
 import 'dotenv/config';
 
-import express, { Application, Request, Response, NextFunction } from 'express';
+import crypto from 'crypto';
 import cors from 'cors';
-import helmet from 'helmet';
+import express, { Application, NextFunction, Request, Response } from 'express';
 import rateLimit from 'express-rate-limit';
+import helmet from 'helmet';
 import { createLogger, format, transports } from 'winston';
 
-import { stripeWebhookHandler } from './webhooks/stripe.webhook';
+import { loadAppConfig } from './config/app';
 import { githubWebhookHandler } from './webhooks/github.webhook';
+import { stripeWebhookHandler } from './webhooks/stripe.webhook';
+
+const appConfig = loadAppConfig();
 
 const logger = createLogger({
-  level: process.env.LOG_LEVEL ?? 'info',
-  format: format.combine(
-    format.timestamp(),
-    format.errors({ stack: true }),
-    format.json()
-  ),
+  level: appConfig.logLevel,
+  format: format.combine(format.timestamp(), format.errors({ stack: true }), format.json()),
   transports: [new transports.Console()],
 });
 
-function createApp(): Application {
+function requestIdMiddleware(req: Request, res: Response, next: NextFunction): void {
+  const inboundRequestId = req.header('x-request-id');
+  const requestId = inboundRequestId && inboundRequestId.trim() ? inboundRequestId : crypto.randomUUID();
+
+  res.setHeader('x-request-id', requestId);
+  res.locals.requestId = requestId;
+  next();
+}
+
+function createApp(config = appConfig): Application {
   const app: Application = express();
 
   const globalLimiter = rateLimit({
-    windowMs: 60_000,
-    max: 100,
+    windowMs: config.globalRateLimit.windowMs,
+    max: config.globalRateLimit.max,
     standardHeaders: true,
     legacyHeaders: false,
     message: { error: 'Too many requests, please try again later.' },
   });
 
   const webhookLimiter = rateLimit({
-    windowMs: 60_000,
-    max: 30,
+    windowMs: config.webhookRateLimit.windowMs,
+    max: config.webhookRateLimit.max,
     standardHeaders: true,
     legacyHeaders: false,
     message: { error: 'Too many webhook requests.' },
   });
 
+  app.disable('x-powered-by');
+  app.use(requestIdMiddleware);
+
   app.post(
     '/webhooks/stripe',
     webhookLimiter,
-    express.raw({ type: 'application/json', limit: '1mb' }),
+    express.raw({ type: 'application/json', limit: config.jsonBodyLimit }),
     stripeWebhookHandler
   );
 
   app.post(
     '/webhooks/github',
     webhookLimiter,
-    express.raw({ type: 'application/json', limit: '1mb' }),
+    express.raw({ type: 'application/json', limit: config.jsonBodyLimit }),
     githubWebhookHandler
   );
 
   app.use(globalLimiter);
   app.use(helmet());
-  app.use(cors({
-    origin: process.env.CORS_ORIGIN ?? 'http://localhost:3000',
-    credentials: process.env.CORS_CREDENTIALS === 'true',
-  }));
-  app.use(express.json());
+  app.use(
+    cors({
+      origin: config.corsOrigin,
+      credentials: config.corsCredentials,
+    })
+  );
+  app.use(express.json({ limit: config.jsonBodyLimit }));
 
   app.get('/health', (_req: Request, res: Response) => {
-    res.json({ status: 'ok', timestamp: new Date().toISOString() });
+    res.json({
+      status: 'ok',
+      service: config.serviceName,
+      version: config.version,
+      timestamp: new Date().toISOString(),
+    });
+  });
+
+  app.get('/ready', (_req: Request, res: Response) => {
+    res.json({
+      status: 'ready',
+      service: config.serviceName,
+      dependencies: {
+        stripeWebhook: 'lazy-configured',
+        githubWebhook: 'lazy-configured',
+      },
+    });
   });
 
   app.get('/', (_req: Request, res: Response) => {
     res.json({
-      name: 'openclaw-revenue-engine',
-      version: process.env.npm_package_version ?? '1.0.0',
+      name: config.serviceName,
+      version: config.version,
       docs: '/health',
+      readiness: '/ready',
     });
   });
 
   app.use((_req: Request, res: Response) => {
-    res.status(404).json({ error: 'Not Found' });
+    res.status(404).json({ error: 'Not Found', requestId: res.locals.requestId });
   });
 
   app.use((err: Error, req: Request, res: Response, _next: NextFunction) => {
@@ -88,17 +119,18 @@ function createApp(): Application {
       path: req.path,
       method: req.method,
       status,
+      requestId: res.locals.requestId,
     });
 
     if (status === 413) {
-      res.status(413).json({ error: 'Payload Too Large' });
+      res.status(413).json({ error: 'Payload Too Large', requestId: res.locals.requestId });
       return;
     }
     if (status >= 400 && status < 500) {
-      res.status(status).json({ error: err.message || 'Bad Request' });
+      res.status(status).json({ error: err.message || 'Bad Request', requestId: res.locals.requestId });
       return;
     }
-    res.status(500).json({ error: 'Internal Server Error' });
+    res.status(500).json({ error: 'Internal Server Error', requestId: res.locals.requestId });
   });
 
   return app;
@@ -106,5 +138,5 @@ function createApp(): Application {
 
 const app = createApp();
 
-export { createApp, logger };
+export { appConfig, createApp, logger };
 export default app;

--- a/src/mcp/planner.ts
+++ b/src/mcp/planner.ts
@@ -1,0 +1,55 @@
+import { AgentManifest } from '../agents/types';
+import { loadMcpServers } from './registry';
+import { McpUsagePlan } from './types';
+
+function inferCapability(tool: string): string {
+  if (tool.includes('github') || tool.includes('repo') || tool.includes('pull_request')) {
+    return 'repo_read';
+  }
+  if (tool.includes('runbook') || tool.includes('policy') || tool.includes('docs')) {
+    return 'file_read';
+  }
+  if (tool.includes('secret')) {
+    return 'secret_read';
+  }
+  return 'file_read';
+}
+
+export function planMcpUsage(agent: AgentManifest): McpUsagePlan[] {
+  const servers = loadMcpServers();
+
+  return agent.allowed_tools.map((tool) => {
+    const capability = inferCapability(tool);
+    const server = servers.find((candidate) => candidate.allowed_capabilities.includes(capability));
+
+    if (!server) {
+      return {
+        server_id: 'none',
+        server_name: 'No compatible MCP server',
+        capability,
+        purpose: `No configured MCP server can satisfy tool ${tool}.`,
+        safe_to_execute: false,
+        blocked_reason: 'missing_capability',
+      };
+    }
+
+    if (server.blocked_capabilities.includes(capability)) {
+      return {
+        server_id: server.id,
+        server_name: server.name,
+        capability,
+        purpose: `Tool ${tool} maps to blocked capability ${capability}.`,
+        safe_to_execute: false,
+        blocked_reason: 'capability_blocked',
+      };
+    }
+
+    return {
+      server_id: server.id,
+      server_name: server.name,
+      capability,
+      purpose: `Use ${server.name} for ${tool} via ${capability}.`,
+      safe_to_execute: true,
+    };
+  });
+}

--- a/src/mcp/registry.ts
+++ b/src/mcp/registry.ts
@@ -1,0 +1,52 @@
+import fs from 'fs';
+import path from 'path';
+
+import { McpInventory, McpServerConfig, McpServerView } from './types';
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+
+function readInventory(inventoryPath = path.join(repoRoot, 'mcp', 'servers.json')): McpInventory {
+  return JSON.parse(fs.readFileSync(inventoryPath, 'utf8')) as McpInventory;
+}
+
+function validateServer(server: McpServerConfig): McpServerConfig {
+  if (!server.id || !server.name || !server.transport || !server.command) {
+    throw new Error('Invalid MCP server config: id, name, transport, and command are required');
+  }
+  if (!Array.isArray(server.allowed_capabilities) || !Array.isArray(server.blocked_capabilities)) {
+    throw new Error(`Invalid MCP server ${server.id}: capabilities must be arrays`);
+  }
+  if (!server.blocked_capabilities.includes('secret_read')) {
+    throw new Error(`Invalid MCP server ${server.id}: secret_read must be blocked`);
+  }
+  return server;
+}
+
+export function loadMcpServers(): McpServerConfig[] {
+  const inventory = readInventory();
+  return inventory.servers.map(validateServer);
+}
+
+export function getMcpServer(serverId: string): McpServerConfig {
+  const server = loadMcpServers().find((item) => item.id === serverId);
+  if (!server) {
+    throw new Error(`Unknown MCP server: ${serverId}`);
+  }
+  return server;
+}
+
+export function viewMcpServers(): McpServerView[] {
+  return loadMcpServers().map((server) => {
+    const missingEnv = server.required_env.filter((key) => !process.env[key]);
+    return {
+      id: server.id,
+      name: server.name,
+      transport: server.transport,
+      allowed_capabilities: server.allowed_capabilities,
+      blocked_capabilities: server.blocked_capabilities,
+      purpose: server.purpose,
+      configured: missingEnv.length === 0,
+      missing_env: missingEnv,
+    };
+  });
+}

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -1,0 +1,36 @@
+export interface McpServerConfig {
+  id: string;
+  name: string;
+  transport: 'stdio' | 'http' | 'sse';
+  command: string;
+  args: string[];
+  required_env: string[];
+  allowed_capabilities: string[];
+  blocked_capabilities: string[];
+  purpose: string;
+}
+
+export interface McpInventory {
+  schema_version: string;
+  servers: McpServerConfig[];
+}
+
+export interface McpServerView {
+  id: string;
+  name: string;
+  transport: McpServerConfig['transport'];
+  allowed_capabilities: string[];
+  blocked_capabilities: string[];
+  purpose: string;
+  configured: boolean;
+  missing_env: string[];
+}
+
+export interface McpUsagePlan {
+  server_id: string;
+  server_name: string;
+  capability: string;
+  purpose: string;
+  safe_to_execute: boolean;
+  blocked_reason?: string;
+}

--- a/src/reviews/reviewQueue.ts
+++ b/src/reviews/reviewQueue.ts
@@ -1,0 +1,83 @@
+import crypto from 'crypto';
+
+import { AgentRunResult } from '../agents/types';
+
+export type ReviewStatus = 'pending' | 'approved' | 'rejected';
+
+export interface ReviewItem {
+  review_id: string;
+  request_id: string;
+  agent_id: string;
+  risk_level: AgentRunResult['risk_level'];
+  status: ReviewStatus;
+  reason: string;
+  findings: AgentRunResult['findings'];
+  recommended_actions: string[];
+  created_at: string;
+  reviewed_at?: string;
+  reviewer?: string;
+  decision_note?: string;
+}
+
+const reviewItems: ReviewItem[] = [];
+
+function buildReason(result: AgentRunResult): string {
+  if (result.risk_level === 'critical') return 'Critical risk requires human review.';
+  if (result.findings.length > 0) return 'Guardrail findings require human review.';
+  return 'Model/profile policy requires human review.';
+}
+
+export function enqueueReview(result: AgentRunResult): ReviewItem | undefined {
+  if (!result.human_review_required) return undefined;
+
+  const existing = reviewItems.find((item) => item.request_id === result.request_id);
+  if (existing) return existing;
+
+  const item: ReviewItem = {
+    review_id: crypto.randomUUID(),
+    request_id: result.request_id,
+    agent_id: result.agent_id,
+    risk_level: result.risk_level,
+    status: 'pending',
+    reason: buildReason(result),
+    findings: result.findings,
+    recommended_actions: result.recommended_actions,
+    created_at: new Date().toISOString(),
+  };
+
+  reviewItems.unshift(item);
+  return item;
+}
+
+export function listReviews(status?: ReviewStatus): ReviewItem[] {
+  return status ? reviewItems.filter((item) => item.status === status) : [...reviewItems];
+}
+
+export function getReview(reviewId: string): ReviewItem | undefined {
+  return reviewItems.find((item) => item.review_id === reviewId);
+}
+
+export function decideReview(
+  reviewId: string,
+  status: Exclude<ReviewStatus, 'pending'>,
+  reviewer: string,
+  decisionNote?: string,
+): ReviewItem {
+  const item = getReview(reviewId);
+  if (!item) {
+    throw new Error(`Unknown review_id: ${reviewId}`);
+  }
+  if (item.status !== 'pending') {
+    throw new Error(`Review ${reviewId} has already been ${item.status}`);
+  }
+
+  item.status = status;
+  item.reviewed_at = new Date().toISOString();
+  item.reviewer = reviewer;
+  item.decision_note = decisionNote;
+  return item;
+}
+
+export function clearReviewQueueForTests(): void {
+  reviewItems.length = 0;
+}

--- a/src/routes/agents.ts
+++ b/src/routes/agents.ts
@@ -1,7 +1,9 @@
 import { Router, Request, Response } from 'express';
 import { z } from 'zod';
 
+import { getAgentRun, listAgentRuns, recordAgentRun } from '../agents/auditLog';
 import { listAgents, runAgent } from '../agents/runner';
+import { enqueueReview } from '../reviews/reviewQueue';
 
 const runAgentSchema = z.object({
   request_id: z.string().optional(),
@@ -17,6 +19,21 @@ agentsRouter.get('/', (_req: Request, res: Response) => {
   res.json({ agents: listAgents() });
 });
 
+agentsRouter.get('/runs', (req: Request, res: Response) => {
+  const rawLimit = typeof req.query.limit === 'string' ? Number.parseInt(req.query.limit, 10) : 50;
+  const limit = Number.isFinite(rawLimit) ? rawLimit : 50;
+  res.json({ runs: listAgentRuns(limit) });
+});
+
+agentsRouter.get('/runs/:requestId', (req: Request, res: Response) => {
+  const record = getAgentRun(req.params.requestId);
+  if (!record) {
+    res.status(404).json({ error: `Unknown request_id: ${req.params.requestId}` });
+    return;
+  }
+  res.json({ run: record });
+});
+
 agentsRouter.post('/run', (req: Request, res: Response) => {
   const parsed = runAgentSchema.safeParse(req.body);
   if (!parsed.success) {
@@ -28,7 +45,10 @@ agentsRouter.post('/run', (req: Request, res: Response) => {
   }
 
   try {
-    res.json(runAgent(parsed.data));
+    const result = runAgent(parsed.data);
+    const audit = recordAgentRun(parsed.data, result);
+    const review = enqueueReview(result);
+    res.json({ ...result, audit, review });
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Unknown agent runtime error';
     res.status(400).json({ error: message });

--- a/src/routes/agents.ts
+++ b/src/routes/agents.ts
@@ -1,0 +1,38 @@
+import { Router, Request, Response } from 'express';
+import { z } from 'zod';
+
+import { listAgents, runAgent } from '../agents/runner';
+
+const runAgentSchema = z.object({
+  request_id: z.string().optional(),
+  agent_id: z.string().min(1),
+  objective: z.string().min(1),
+  event_summary: z.string().optional(),
+  context: z.record(z.unknown()).optional(),
+});
+
+const agentsRouter = Router();
+
+agentsRouter.get('/', (_req: Request, res: Response) => {
+  res.json({ agents: listAgents() });
+});
+
+agentsRouter.post('/run', (req: Request, res: Response) => {
+  const parsed = runAgentSchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({
+      error: 'Invalid agent run payload',
+      details: parsed.error.flatten(),
+    });
+    return;
+  }
+
+  try {
+    res.json(runAgent(parsed.data));
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown agent runtime error';
+    res.status(400).json({ error: message });
+  }
+});
+
+export { agentsRouter };

--- a/src/routes/mcp.ts
+++ b/src/routes/mcp.ts
@@ -1,0 +1,33 @@
+import { Router, Request, Response } from 'express';
+
+import { getMcpServer, viewMcpServers } from '../mcp/registry';
+
+const mcpRouter = Router();
+
+mcpRouter.get('/servers', (_req: Request, res: Response) => {
+  res.json({ servers: viewMcpServers() });
+});
+
+mcpRouter.get('/servers/:serverId', (req: Request, res: Response) => {
+  try {
+    const server = getMcpServer(req.params.serverId);
+    const missingEnv = server.required_env.filter((key) => !process.env[key]);
+    res.json({
+      server: {
+        id: server.id,
+        name: server.name,
+        transport: server.transport,
+        allowed_capabilities: server.allowed_capabilities,
+        blocked_capabilities: server.blocked_capabilities,
+        purpose: server.purpose,
+        configured: missingEnv.length === 0,
+        missing_env: missingEnv,
+      },
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown MCP runtime error';
+    res.status(404).json({ error: message });
+  }
+});
+
+export { mcpRouter };

--- a/src/routes/reviews.ts
+++ b/src/routes/reviews.ts
@@ -1,0 +1,68 @@
+import { Router, Request, Response } from 'express';
+import { z } from 'zod';
+
+import { decideReview, getReview, listReviews, ReviewStatus } from '../reviews/reviewQueue';
+
+const decisionSchema = z.object({
+  reviewer: z.string().min(1),
+  decision_note: z.string().optional(),
+});
+
+function parseReviewStatus(value: unknown): ReviewStatus | undefined {
+  if (value === 'pending' || value === 'approved' || value === 'rejected') return value;
+  return undefined;
+}
+
+const reviewsRouter = Router();
+
+reviewsRouter.get('/', (req: Request, res: Response) => {
+  const status = parseReviewStatus(req.query.status);
+  res.json({ reviews: listReviews(status) });
+});
+
+reviewsRouter.get('/pending', (_req: Request, res: Response) => {
+  res.json({ reviews: listReviews('pending') });
+});
+
+reviewsRouter.get('/:reviewId', (req: Request, res: Response) => {
+  const review = getReview(req.params.reviewId);
+  if (!review) {
+    res.status(404).json({ error: `Unknown review_id: ${req.params.reviewId}` });
+    return;
+  }
+  res.json({ review });
+});
+
+reviewsRouter.post('/:reviewId/approve', (req: Request, res: Response) => {
+  const parsed = decisionSchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({ error: 'Invalid review decision payload', details: parsed.error.flatten() });
+    return;
+  }
+
+  try {
+    const review = decideReview(req.params.reviewId, 'approved', parsed.data.reviewer, parsed.data.decision_note);
+    res.json({ review });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown review decision error';
+    res.status(400).json({ error: message });
+  }
+});
+
+reviewsRouter.post('/:reviewId/reject', (req: Request, res: Response) => {
+  const parsed = decisionSchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({ error: 'Invalid review decision payload', details: parsed.error.flatten() });
+    return;
+  }
+
+  try {
+    const review = decideReview(req.params.reviewId, 'rejected', parsed.data.reviewer, parsed.data.decision_note);
+    res.json({ review });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown review decision error';
+    res.status(400).json({ error: message });
+  }
+});
+
+export { reviewsRouter };

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,7 +1,31 @@
-import app, { logger } from './index';
+import http from 'http';
 
-const PORT = Number(process.env.PORT ?? 3000);
+import app, { appConfig, logger } from './index';
 
-app.listen(PORT, () => {
-  logger.info(`[openclaw-revenue-engine] Listening on port ${PORT}`);
+const server = http.createServer(app);
+
+server.listen(appConfig.port, () => {
+  logger.info('[openclaw-revenue-engine] Listening', {
+    port: appConfig.port,
+    env: appConfig.nodeEnv,
+    service: appConfig.serviceName,
+    version: appConfig.version,
+  });
 });
+
+function shutdown(signal: NodeJS.Signals): void {
+  logger.info('[openclaw-revenue-engine] Shutdown signal received', { signal });
+
+  server.close((error?: Error) => {
+    if (error) {
+      logger.error('[openclaw-revenue-engine] Error during shutdown', { error });
+      process.exit(1);
+    }
+
+    logger.info('[openclaw-revenue-engine] Shutdown complete');
+    process.exit(0);
+  });
+}
+
+process.on('SIGTERM', shutdown);
+process.on('SIGINT', shutdown);

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,7 @@
+import app, { logger } from './index';
+
+const PORT = Number(process.env.PORT ?? 3000);
+
+app.listen(PORT, () => {
+  logger.info(`[openclaw-revenue-engine] Listening on port ${PORT}`);
+});

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -1,0 +1,21 @@
+import { Response } from 'express';
+
+export function sendBadRequest(res: Response, error: string): void {
+  res.status(400).json({ error });
+}
+
+export function sendUnauthorized(res: Response, error: string): void {
+  res.status(401).json({ error });
+}
+
+export function sendServiceMisconfigured(res: Response, provider: string): void {
+  res.status(500).json({ error: `${provider} webhook is not configured` });
+}
+
+export function sendWebhookProcessingError(res: Response): void {
+  res.status(500).json({ error: 'Internal webhook processing error' });
+}
+
+export function getHeaderValue(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}

--- a/src/webhooks/github.webhook.ts
+++ b/src/webhooks/github.webhook.ts
@@ -1,129 +1,125 @@
-import { Request, Response } from 'express';
 import crypto from 'crypto';
+import { Request, Response } from 'express';
 
-function requireEnv(key: string): string {
-  const val = process.env[key];
-  if (!val) {
-    throw new Error(`Missing required environment variable: ${key}`);
-  }
-  return val;
+import { getRequiredEnv, toErrorMessage } from '../config/env';
+import {
+  getHeaderValue,
+  sendBadRequest,
+  sendServiceMisconfigured,
+  sendUnauthorized,
+  sendWebhookProcessingError,
+} from '../utils/http';
+
+type GitHubPayload = Record<string, unknown>;
+
+interface GitHubWebhookContext {
+  signature: string;
+  eventName: string;
+  delivery?: string;
+  payload: GitHubPayload;
 }
 
-/**
- * GitHub Webhook Handler
- *
- * Verifies the GitHub HMAC-SHA256 signature from the X-Hub-Signature-256
- * header, then routes each event to its appropriate handler.
- *
- * IMPORTANT: Register this handler with express.raw({ type: 'application/json' })
- * before global express.json() middleware.
- */
-export function githubWebhookHandler(
-  req: Request,
-  res: Response
-): void {
-  const rawSignature = req.headers['x-hub-signature-256'];
-  const event = req.headers['x-github-event'];
-  const deliveryId = req.headers['x-github-delivery'];
+export function githubWebhookHandler(req: Request, res: Response): void {
+  let context: GitHubWebhookContext;
 
-  const signature = Array.isArray(rawSignature) ? rawSignature[0] : rawSignature;
-  const eventName = Array.isArray(event) ? event[0] : event;
-  const delivery = Array.isArray(deliveryId) ? deliveryId[0] : deliveryId;
-
-  if (!signature) {
-    res.status(400).json({ error: 'Missing X-Hub-Signature-256 header' });
-    return;
-  }
-
-  if (!eventName) {
-    res.status(400).json({ error: 'Missing X-GitHub-Event header' });
+  try {
+    context = buildGitHubWebhookContext(req);
+  } catch (err) {
+    sendBadRequest(res, toErrorMessage(err));
     return;
   }
 
   let githubWebhookSecret: string;
   try {
-    githubWebhookSecret = requireEnv('GITHUB_WEBHOOK_SECRET');
+    githubWebhookSecret = getRequiredEnv('GITHUB_WEBHOOK_SECRET');
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Unknown error';
-    console.error(`GitHub webhook configuration failure: ${message}`);
-    res.status(500).json({ error: 'GitHub webhook is not configured' });
+    console.error(`GitHub webhook configuration failure: ${toErrorMessage(err)}`);
+    sendServiceMisconfigured(res, 'GitHub');
     return;
   }
 
-  const isValid = verifyGitHubSignature(
-    req.body as Buffer,
-    signature,
-    githubWebhookSecret
+  if (!verifyGitHubSignature(req.body as Buffer, context.signature, githubWebhookSecret)) {
+    console.error(`GitHub webhook signature mismatch for delivery ${context.delivery ?? 'unknown'}`);
+    sendUnauthorized(res, 'Invalid webhook signature');
+    return;
+  }
+
+  console.log(
+    `GitHub webhook received: ${context.eventName} [delivery: ${context.delivery ?? 'unknown'}]`
   );
 
-  if (!isValid) {
-    console.error(`GitHub webhook signature mismatch for delivery ${delivery ?? 'unknown'}`);
-    res.status(401).json({ error: 'Invalid webhook signature' });
-    return;
-  }
-
-  let payload: Record<string, unknown>;
   try {
-    payload = req.body instanceof Buffer
-      ? (JSON.parse(req.body.toString('utf8')) as Record<string, unknown>)
-      : (req.body as Record<string, unknown>);
-  } catch (err) {
-    const message = err instanceof Error ? err.message : 'Unknown error';
-    console.error(`Invalid GitHub webhook JSON for delivery ${delivery ?? 'unknown'}: ${message}`);
-    res.status(400).json({ error: 'Invalid webhook JSON payload' });
-    return;
-  }
-
-  console.log(`GitHub webhook received: ${eventName} [delivery: ${delivery ?? 'unknown'}]`);
-
-  try {
-    switch (eventName) {
-      case 'push':
-        handlePushEvent(payload);
-        break;
-      case 'pull_request':
-        handlePullRequestEvent(payload);
-        break;
-      case 'release':
-        handleReleaseEvent(payload);
-        break;
-      case 'workflow_run':
-        handleWorkflowRunEvent(payload);
-        break;
-      case 'repository_dispatch':
-        handleRepositoryDispatch(payload);
-        break;
-      case 'ping':
-        console.log('GitHub webhook ping received - connection verified');
-        break;
-      default:
-        console.log(`Unhandled GitHub event: ${eventName}`);
-    }
+    dispatchGitHubEvent(context.eventName, context.payload);
     res.status(200).json({
       received: true,
-      event: eventName,
-      delivery,
+      event: context.eventName,
+      delivery: context.delivery,
     });
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Unknown error';
-    console.error(`Error processing GitHub webhook ${eventName}: ${message}`);
-    res.status(500).json({ error: 'Internal webhook processing error' });
+    console.error(`Error processing GitHub webhook ${context.eventName}: ${toErrorMessage(err)}`);
+    sendWebhookProcessingError(res);
   }
 }
 
-function verifyGitHubSignature(
-  body: Buffer,
-  signature: string,
-  secret: string
-): boolean {
+function buildGitHubWebhookContext(req: Request): GitHubWebhookContext {
+  const signature = getHeaderValue(req.headers['x-hub-signature-256']);
+  const eventName = getHeaderValue(req.headers['x-github-event']);
+  const delivery = getHeaderValue(req.headers['x-github-delivery']);
+
+  if (!signature) {
+    throw new Error('Missing X-Hub-Signature-256 header');
+  }
+
+  if (!eventName) {
+    throw new Error('Missing X-GitHub-Event header');
+  }
+
+  return {
+    signature,
+    eventName,
+    delivery,
+    payload: parseGitHubPayload(req.body),
+  };
+}
+
+function parseGitHubPayload(body: unknown): GitHubPayload {
+  if (body instanceof Buffer) {
+    return JSON.parse(body.toString('utf8')) as GitHubPayload;
+  }
+
+  if (body && typeof body === 'object') {
+    return body as GitHubPayload;
+  }
+
+  throw new Error('Invalid webhook JSON payload');
+}
+
+function dispatchGitHubEvent(eventName: string, payload: GitHubPayload): void {
+  const handlers: Record<string, (payload: GitHubPayload) => void> = {
+    push: handlePushEvent,
+    pull_request: handlePullRequestEvent,
+    release: handleReleaseEvent,
+    workflow_run: handleWorkflowRunEvent,
+    repository_dispatch: handleRepositoryDispatch,
+    ping: () => console.log('GitHub webhook ping received - connection verified'),
+  };
+
+  const handler = handlers[eventName];
+  if (!handler) {
+    console.log(`Unhandled GitHub event: ${eventName}`);
+    return;
+  }
+
+  handler(payload);
+}
+
+function verifyGitHubSignature(body: Buffer, signature: string, secret: string): boolean {
   const hmac = crypto.createHmac('sha256', secret);
   hmac.update(body);
   const digest = `sha256=${hmac.digest('hex')}`;
+
   try {
-    return crypto.timingSafeEqual(
-      Buffer.from(digest, 'utf8'),
-      Buffer.from(signature, 'utf8')
-    );
+    return crypto.timingSafeEqual(Buffer.from(digest, 'utf8'), Buffer.from(signature, 'utf8'));
   } catch {
     return false;
   }
@@ -136,47 +132,48 @@ function requireRecord(value: unknown, field: string): Record<string, unknown> {
   return value as Record<string, unknown>;
 }
 
-function handlePushEvent(payload: Record<string, unknown>): void {
-  const ref = String(payload['ref']);
-  const repository = requireRecord(payload['repository'], 'repository');
-  const pusher = requireRecord(payload['pusher'], 'pusher');
-  const repo = String(repository['full_name']);
-  const pusherName = String(pusher['name']);
-  console.log(`Push to ${repo} on ${ref} by ${pusherName}`);
+function readString(record: Record<string, unknown>, field: string): string {
+  const value = record[field];
+  if (typeof value !== 'string') {
+    throw new Error(`Missing or invalid GitHub webhook field: ${field}`);
+  }
+  return value;
 }
 
-function handlePullRequestEvent(payload: Record<string, unknown>): void {
-  const action = String(payload['action']);
-  const pr = requireRecord(payload['pull_request'], 'pull_request');
-  const repository = requireRecord(payload['repository'], 'repository');
-  const number = pr['number'] as number;
-  const title = String(pr['title']);
-  const repo = String(repository['full_name']);
-  console.log(`PR #${number} ${action} in ${repo}: ${title}`);
+function handlePushEvent(payload: GitHubPayload): void {
+  const repository = requireRecord(payload.repository, 'repository');
+  const pusher = requireRecord(payload.pusher, 'pusher');
+  console.log(
+    `Push to ${readString(repository, 'full_name')} on ${String(payload.ref)} by ${readString(pusher, 'name')}`
+  );
 }
 
-function handleReleaseEvent(payload: Record<string, unknown>): void {
-  const action = String(payload['action']);
-  const release = requireRecord(payload['release'], 'release');
-  const repository = requireRecord(payload['repository'], 'repository');
-  const tag = String(release['tag_name']);
-  const repo = String(repository['full_name']);
-  console.log(`Release ${action}: ${tag} in ${repo}`);
+function handlePullRequestEvent(payload: GitHubPayload): void {
+  const pr = requireRecord(payload.pull_request, 'pull_request');
+  const repository = requireRecord(payload.repository, 'repository');
+  console.log(
+    `PR #${String(pr.number)} ${String(payload.action)} in ${readString(repository, 'full_name')}: ${String(pr.title)}`
+  );
 }
 
-function handleWorkflowRunEvent(payload: Record<string, unknown>): void {
-  const run = requireRecord(payload['workflow_run'], 'workflow_run');
-  const repository = requireRecord(payload['repository'], 'repository');
-  const name = String(run['name']);
-  const status = String(run['status']);
-  const conclusion = String(run['conclusion']);
-  const repo = String(repository['full_name']);
-  console.log(`Workflow "${name}" in ${repo}: ${status} / ${conclusion}`);
+function handleReleaseEvent(payload: GitHubPayload): void {
+  const release = requireRecord(payload.release, 'release');
+  const repository = requireRecord(payload.repository, 'repository');
+  console.log(
+    `Release ${String(payload.action)}: ${readString(release, 'tag_name')} in ${readString(repository, 'full_name')}`
+  );
 }
 
-function handleRepositoryDispatch(payload: Record<string, unknown>): void {
-  const eventType = String(payload['action']);
-  const clientPayload = requireRecord(payload['client_payload'], 'client_payload');
-  console.log(`repository_dispatch event: ${eventType}`);
+function handleWorkflowRunEvent(payload: GitHubPayload): void {
+  const run = requireRecord(payload.workflow_run, 'workflow_run');
+  const repository = requireRecord(payload.repository, 'repository');
+  console.log(
+    `Workflow "${String(run.name)}" in ${readString(repository, 'full_name')}: ${String(run.status)} / ${String(run.conclusion)}`
+  );
+}
+
+function handleRepositoryDispatch(payload: GitHubPayload): void {
+  const clientPayload = requireRecord(payload.client_payload, 'client_payload');
+  console.log(`repository_dispatch event: ${String(payload.action)}`);
   console.log('Client payload:', JSON.stringify(clientPayload, null, 2));
 }

--- a/src/webhooks/github.webhook.ts
+++ b/src/webhooks/github.webhook.ts
@@ -1,7 +1,6 @@
 import { Request, Response } from 'express';
 import crypto from 'crypto';
 
-// ─── Fail fast at module load if required env vars are missing ───
 function requireEnv(key: string): string {
   const val = process.env[key];
   if (!val) {
@@ -10,30 +9,14 @@ function requireEnv(key: string): string {
   return val;
 }
 
-const githubWebhookSecret = requireEnv('GITHUB_WEBHOOK_SECRET');
-
 /**
  * GitHub Webhook Handler
  *
  * Verifies the GitHub HMAC-SHA256 signature from the X-Hub-Signature-256
  * header, then routes each event to its appropriate handler.
  *
- * IMPORTANT: This handler must be registered with express.raw({ type: 'application/json' })
- * in index.ts BEFORE the global express.json() middleware.
- *
- * Supported events:
- *   - push              (code pushed to any branch)
- *   - pull_request      (PR opened, closed, merged, synchronized)
- *   - release           (release published)
- *   - workflow_run      (GitHub Actions workflow completed)
- *   - repository_dispatch (custom event triggered externally)
- *
- * Fix for @typescript-eslint/require-await:
- * The handler does not currently perform any async I/O (DB writes, HTTP calls,
- * etc.). Marking it async when no await is present triggers the lint rule.
- * Removed the async keyword and changed the return type to void.
- * The asyncHandler wrapper in index.ts still handles error propagation for
- * when async operations are added in the future — just restore async/await then.
+ * IMPORTANT: Register this handler with express.raw({ type: 'application/json' })
+ * before global express.json() middleware.
  */
 export function githubWebhookHandler(
   req: Request,
@@ -57,6 +40,16 @@ export function githubWebhookHandler(
     return;
   }
 
+  let githubWebhookSecret: string;
+  try {
+    githubWebhookSecret = requireEnv('GITHUB_WEBHOOK_SECRET');
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    console.error(`GitHub webhook configuration failure: ${message}`);
+    res.status(500).json({ error: 'GitHub webhook is not configured' });
+    return;
+  }
+
   const isValid = verifyGitHubSignature(
     req.body as Buffer,
     signature,
@@ -69,10 +62,17 @@ export function githubWebhookHandler(
     return;
   }
 
-  const payload: Record<string, unknown> =
-    req.body instanceof Buffer
+  let payload: Record<string, unknown>;
+  try {
+    payload = req.body instanceof Buffer
       ? (JSON.parse(req.body.toString('utf8')) as Record<string, unknown>)
       : (req.body as Record<string, unknown>);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    console.error(`Invalid GitHub webhook JSON for delivery ${delivery ?? 'unknown'}: ${message}`);
+    res.status(400).json({ error: 'Invalid webhook JSON payload' });
+    return;
+  }
 
   console.log(`GitHub webhook received: ${eventName} [delivery: ${delivery ?? 'unknown'}]`);
 
@@ -111,10 +111,6 @@ export function githubWebhookHandler(
   }
 }
 
-// ---------------------------------------------------------------------------
-// Signature Verification
-// ---------------------------------------------------------------------------
-
 function verifyGitHubSignature(
   body: Buffer,
   signature: string,
@@ -133,51 +129,54 @@ function verifyGitHubSignature(
   }
 }
 
-// ---------------------------------------------------------------------------
-// Event Handlers
-// ---------------------------------------------------------------------------
+function requireRecord(value: unknown, field: string): Record<string, unknown> {
+  if (!value || typeof value !== 'object') {
+    throw new Error(`Missing or invalid GitHub webhook field: ${field}`);
+  }
+  return value as Record<string, unknown>;
+}
 
 function handlePushEvent(payload: Record<string, unknown>): void {
   const ref = String(payload['ref']);
-  const repo = String((payload['repository'] as Record<string, unknown>)['full_name']);
-  const pusher = String((payload['pusher'] as Record<string, unknown>)['name']);
-  console.log(`Push to ${repo} on ${ref} by ${pusher}`);
-  // TODO: Trigger deployment pipeline, invalidate caches, notify team
+  const repository = requireRecord(payload['repository'], 'repository');
+  const pusher = requireRecord(payload['pusher'], 'pusher');
+  const repo = String(repository['full_name']);
+  const pusherName = String(pusher['name']);
+  console.log(`Push to ${repo} on ${ref} by ${pusherName}`);
 }
 
 function handlePullRequestEvent(payload: Record<string, unknown>): void {
   const action = String(payload['action']);
-  const pr = payload['pull_request'] as Record<string, unknown>;
+  const pr = requireRecord(payload['pull_request'], 'pull_request');
+  const repository = requireRecord(payload['repository'], 'repository');
   const number = pr['number'] as number;
   const title = String(pr['title']);
-  const repo = String((payload['repository'] as Record<string, unknown>)['full_name']);
+  const repo = String(repository['full_name']);
   console.log(`PR #${number} ${action} in ${repo}: ${title}`);
-  // TODO: Update review status, trigger preview deploys, notify Slack
 }
 
 function handleReleaseEvent(payload: Record<string, unknown>): void {
   const action = String(payload['action']);
-  const release = payload['release'] as Record<string, unknown>;
+  const release = requireRecord(payload['release'], 'release');
+  const repository = requireRecord(payload['repository'], 'repository');
   const tag = String(release['tag_name']);
-  const repo = String((payload['repository'] as Record<string, unknown>)['full_name']);
+  const repo = String(repository['full_name']);
   console.log(`Release ${action}: ${tag} in ${repo}`);
-  // TODO: Trigger production deploy, update changelog, notify stakeholders
 }
 
 function handleWorkflowRunEvent(payload: Record<string, unknown>): void {
-  const run = payload['workflow_run'] as Record<string, unknown>;
+  const run = requireRecord(payload['workflow_run'], 'workflow_run');
+  const repository = requireRecord(payload['repository'], 'repository');
   const name = String(run['name']);
   const status = String(run['status']);
   const conclusion = String(run['conclusion']);
-  const repo = String((payload['repository'] as Record<string, unknown>)['full_name']);
+  const repo = String(repository['full_name']);
   console.log(`Workflow "${name}" in ${repo}: ${status} / ${conclusion}`);
-  // TODO: Alert on failures, update status dashboards
 }
 
 function handleRepositoryDispatch(payload: Record<string, unknown>): void {
   const eventType = String(payload['action']);
-  const clientPayload = payload['client_payload'] as Record<string, unknown>;
+  const clientPayload = requireRecord(payload['client_payload'], 'client_payload');
   console.log(`repository_dispatch event: ${eventType}`);
   console.log('Client payload:', JSON.stringify(clientPayload, null, 2));
-  // TODO: Handle custom dispatch events (e.g., deploy-staging, run-smoke-tests)
 }

--- a/src/webhooks/stripe.webhook.ts
+++ b/src/webhooks/stripe.webhook.ts
@@ -1,7 +1,6 @@
 import { Request, Response } from 'express';
 import Stripe from 'stripe';
 
-// ─── Fail fast at module load if required env vars are missing ───
 function requireEnv(key: string): string {
   const val = process.env[key];
   if (!val) {
@@ -10,40 +9,25 @@ function requireEnv(key: string): string {
   return val;
 }
 
-const stripe = new Stripe(requireEnv('STRIPE_SECRET_KEY'), {
-  apiVersion: '2024-06-20',
-});
+let stripeClient: Stripe | null = null;
 
-const webhookSecret = requireEnv('STRIPE_WEBHOOK_SECRET');
+function getStripeClient(): Stripe {
+  if (!stripeClient) {
+    stripeClient = new Stripe(requireEnv('STRIPE_SECRET_KEY'), {
+      apiVersion: '2024-06-20',
+    });
+  }
+  return stripeClient;
+}
 
 /**
  * Stripe Webhook Handler
  *
- * Verifies the Stripe signature, then routes each event type
- * to its appropriate handler. Uses raw body for HMAC verification.
+ * Verifies the Stripe signature, then routes each event type to its appropriate
+ * handler. Uses raw body for HMAC verification.
  *
- * IMPORTANT: This handler must be registered with express.raw({ type: 'application/json' })
- * in index.ts BEFORE the global express.json() middleware.
- *
- * Supported events:
- *   - customer.subscription.created
- *   - customer.subscription.updated
- *   - customer.subscription.deleted
- *   - invoice.payment_succeeded
- *   - invoice.payment_failed
- *   - checkout.session.completed
- *
- * Fix for @typescript-eslint/require-await (line 36):
- * stripe.webhooks.constructEvent() is synchronous — it returns Stripe.Event
- * directly, not a Promise. No await expressions exist in this function.
- * Removed the async keyword; the return type changes from Promise<void> to void.
- *
- * Fix for @typescript-eslint/no-unnecessary-type-assertion (lines 65–80):
- * Stripe's SDK now ships precise generic types for event.data.object keyed by
- * event.type via the Stripe.DiscriminatedEvent union. In the switch branches,
- * TypeScript already narrows event to the correct discriminated type, so
- * casting event.data.object with `as Stripe.Subscription` etc. is redundant.
- * Replaced each cast with a typed const that reads from the pre-narrowed event.
+ * IMPORTANT: Register this handler with express.raw({ type: 'application/json' })
+ * before global express.json() middleware.
  */
 export function stripeWebhookHandler(
   req: Request,
@@ -57,22 +41,25 @@ export function stripeWebhookHandler(
 
   let event: Stripe.Event;
   try {
-    event = stripe.webhooks.constructEvent(
+    event = getStripeClient().webhooks.constructEvent(
       req.body as Buffer,
       sig,
-      webhookSecret
+      requireEnv('STRIPE_WEBHOOK_SECRET')
     );
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Unknown error';
-    console.error(`Stripe webhook signature verification failed: ${message}`);
-    res.status(400).json({ error: `Webhook signature verification failed: ${message}` });
+    const isConfigError = message.startsWith('Missing required environment variable:');
+
+    console.error(`Stripe webhook setup/signature failure: ${message}`);
+    res.status(isConfigError ? 500 : 400).json({
+      error: isConfigError ? 'Stripe webhook is not configured' : `Webhook signature verification failed: ${message}`,
+    });
     return;
   }
 
   console.log(`Stripe webhook received: ${event.type} [${event.id}]`);
 
   try {
-    // Using Stripe.DiscriminatedEvent narrowing — no redundant type assertions needed.
     switch (event.type) {
       case 'customer.subscription.created':
         handleSubscriptionCreated(event.data.object);
@@ -103,46 +90,36 @@ export function stripeWebhookHandler(
   }
 }
 
-// ---------------------------------------------------------------------------
-// Event Handlers
-// ---------------------------------------------------------------------------
-
 function handleSubscriptionCreated(subscription: Stripe.Subscription): void {
   console.log(`New subscription created: ${subscription.id}`);
   console.log(`Customer: ${String(subscription.customer)}`);
   console.log(`Status: ${subscription.status}`);
-  // TODO: Provision access, update DB, send welcome email
 }
 
 function handleSubscriptionUpdated(subscription: Stripe.Subscription): void {
   console.log(`Subscription updated: ${subscription.id}`);
   console.log(`New status: ${subscription.status}`);
-  // TODO: Update access level, sync plan changes to DB
 }
 
 function handleSubscriptionDeleted(subscription: Stripe.Subscription): void {
   console.log(`Subscription cancelled: ${subscription.id}`);
   console.log(`Customer: ${String(subscription.customer)}`);
-  // TODO: Revoke access, update DB, send cancellation confirmation
 }
 
 function handlePaymentSucceeded(invoice: Stripe.Invoice): void {
   console.log(`Payment succeeded for invoice: ${invoice.id ?? 'unknown'}`);
   console.log(`Amount: ${invoice.amount_paid} ${invoice.currency}`);
   console.log(`Customer: ${String(invoice.customer)}`);
-  // TODO: Record payment in DB, generate internal invoice record
 }
 
 function handlePaymentFailed(invoice: Stripe.Invoice): void {
   console.log(`Payment failed for invoice: ${invoice.id ?? 'unknown'}`);
   console.log(`Customer: ${String(invoice.customer)}`);
   console.log(`Next retry: ${invoice.next_payment_attempt ?? 'none'}`);
-  // TODO: Send payment failure alert, flag account for retry
 }
 
 function handleCheckoutCompleted(session: Stripe.Checkout.Session): void {
   console.log(`Checkout session completed: ${session.id}`);
   console.log(`Customer: ${String(session.customer)}`);
   console.log(`Payment status: ${session.payment_status}`);
-  // TODO: Activate subscription, send onboarding email
 }

--- a/src/webhooks/stripe.webhook.ts
+++ b/src/webhooks/stripe.webhook.ts
@@ -1,92 +1,92 @@
 import { Request, Response } from 'express';
 import Stripe from 'stripe';
 
-function requireEnv(key: string): string {
-  const val = process.env[key];
-  if (!val) {
-    throw new Error(`Missing required environment variable: ${key}`);
-  }
-  return val;
-}
+import {
+  getRequiredEnv,
+  isMissingRequiredEnvError,
+  toErrorMessage,
+} from '../config/env';
+import {
+  sendBadRequest,
+  sendServiceMisconfigured,
+  sendWebhookProcessingError,
+} from '../utils/http';
 
 let stripeClient: Stripe | null = null;
 
 function getStripeClient(): Stripe {
   if (!stripeClient) {
-    stripeClient = new Stripe(requireEnv('STRIPE_SECRET_KEY'), {
+    stripeClient = new Stripe(getRequiredEnv('STRIPE_SECRET_KEY'), {
       apiVersion: '2024-06-20',
     });
   }
   return stripeClient;
 }
 
-/**
- * Stripe Webhook Handler
- *
- * Verifies the Stripe signature, then routes each event type to its appropriate
- * handler. Uses raw body for HMAC verification.
- *
- * IMPORTANT: Register this handler with express.raw({ type: 'application/json' })
- * before global express.json() middleware.
- */
-export function stripeWebhookHandler(
-  req: Request,
-  res: Response
-): void {
+function buildStripeEvent(req: Request): Stripe.Event {
   const sig = req.headers['stripe-signature'];
   if (!sig) {
-    res.status(400).json({ error: 'Missing stripe-signature header' });
-    return;
+    throw new Error('Missing stripe-signature header');
   }
 
-  let event: Stripe.Event;
-  try {
-    event = getStripeClient().webhooks.constructEvent(
-      req.body as Buffer,
-      sig,
-      requireEnv('STRIPE_WEBHOOK_SECRET')
-    );
-  } catch (err) {
-    const message = err instanceof Error ? err.message : 'Unknown error';
-    const isConfigError = message.startsWith('Missing required environment variable:');
+  return getStripeClient().webhooks.constructEvent(
+    req.body as Buffer,
+    sig,
+    getRequiredEnv('STRIPE_WEBHOOK_SECRET')
+  );
+}
 
+export function stripeWebhookHandler(req: Request, res: Response): void {
+  let event: Stripe.Event;
+
+  try {
+    event = buildStripeEvent(req);
+  } catch (err) {
+    const message = toErrorMessage(err);
     console.error(`Stripe webhook setup/signature failure: ${message}`);
-    res.status(isConfigError ? 500 : 400).json({
-      error: isConfigError ? 'Stripe webhook is not configured' : `Webhook signature verification failed: ${message}`,
-    });
+
+    if (isMissingRequiredEnvError(err)) {
+      sendServiceMisconfigured(res, 'Stripe');
+      return;
+    }
+
+    sendBadRequest(res, `Webhook signature verification failed: ${message}`);
     return;
   }
 
   console.log(`Stripe webhook received: ${event.type} [${event.id}]`);
 
   try {
-    switch (event.type) {
-      case 'customer.subscription.created':
-        handleSubscriptionCreated(event.data.object);
-        break;
-      case 'customer.subscription.updated':
-        handleSubscriptionUpdated(event.data.object);
-        break;
-      case 'customer.subscription.deleted':
-        handleSubscriptionDeleted(event.data.object);
-        break;
-      case 'invoice.payment_succeeded':
-        handlePaymentSucceeded(event.data.object);
-        break;
-      case 'invoice.payment_failed':
-        handlePaymentFailed(event.data.object);
-        break;
-      case 'checkout.session.completed':
-        handleCheckoutCompleted(event.data.object);
-        break;
-      default:
-        console.log(`Unhandled Stripe event type: ${event.type}`);
-    }
+    handleStripeEvent(event);
     res.status(200).json({ received: true, eventType: event.type });
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Unknown error';
-    console.error(`Error processing Stripe webhook ${event.type}: ${message}`);
-    res.status(500).json({ error: 'Internal webhook processing error' });
+    console.error(`Error processing Stripe webhook ${event.type}: ${toErrorMessage(err)}`);
+    sendWebhookProcessingError(res);
+  }
+}
+
+function handleStripeEvent(event: Stripe.Event): void {
+  switch (event.type) {
+    case 'customer.subscription.created':
+      handleSubscriptionCreated(event.data.object);
+      break;
+    case 'customer.subscription.updated':
+      handleSubscriptionUpdated(event.data.object);
+      break;
+    case 'customer.subscription.deleted':
+      handleSubscriptionDeleted(event.data.object);
+      break;
+    case 'invoice.payment_succeeded':
+      handlePaymentSucceeded(event.data.object);
+      break;
+    case 'invoice.payment_failed':
+      handlePaymentFailed(event.data.object);
+      break;
+    case 'checkout.session.completed':
+      handleCheckoutCompleted(event.data.object);
+      break;
+    default:
+      console.log(`Unhandled Stripe event type: ${event.type}`);
   }
 }
 

--- a/tests/unit/agentOps.routes.test.ts
+++ b/tests/unit/agentOps.routes.test.ts
@@ -1,0 +1,124 @@
+import request from 'supertest';
+
+import { clearAgentAuditLogForTests } from '../../src/agents/auditLog';
+import { clearReviewQueueForTests } from '../../src/reviews/reviewQueue';
+
+beforeAll(() => {
+  process.env.STRIPE_SECRET_KEY = 'sk_test_agent_ops_placeholder';
+  process.env.STRIPE_WEBHOOK_SECRET = 'whsec_agent_ops_placeholder';
+  process.env.GITHUB_WEBHOOK_SECRET = 'github_agent_ops_placeholder';
+  process.env.LOG_LEVEL = 'silent';
+});
+
+import app from '../../src/index';
+
+describe('agent operations routes', () => {
+  beforeEach(() => {
+    clearAgentAuditLogForTests();
+    clearReviewQueueForTests();
+  });
+
+  it('records agent runs and exposes run history', async () => {
+    const run = await request(app).post('/agents/run').send({
+      request_id: 'req-audit-1',
+      agent_id: 'revenue_ops_agent',
+      objective: 'Summarize webhook health check status',
+    });
+
+    expect(run.status).toBe(200);
+    expect(run.body.audit).toMatchObject({
+      request_id: 'req-audit-1',
+      agent_id: 'revenue_ops_agent',
+      risk_level: 'low',
+    });
+
+    const list = await request(app).get('/agents/runs');
+    expect(list.status).toBe(200);
+    expect(list.body.runs).toHaveLength(1);
+    expect(list.body.runs[0]).toMatchObject({ request_id: 'req-audit-1' });
+
+    const getOne = await request(app).get('/agents/runs/req-audit-1');
+    expect(getOne.status).toBe(200);
+    expect(getOne.body.run).toMatchObject({ request_id: 'req-audit-1' });
+  });
+
+  it('returns 404 for missing agent audit records', async () => {
+    const res = await request(app).get('/agents/runs/missing');
+    expect(res.status).toBe(404);
+    expect(res.body.error).toContain('Unknown request_id');
+  });
+
+  it('creates a pending review when an agent run requires human review', async () => {
+    const run = await request(app).post('/agents/run').send({
+      request_id: 'req-review-1',
+      agent_id: 'compliance_review_agent',
+      objective: 'Review refund and customer impact for chargeback workflow',
+    });
+
+    expect(run.status).toBe(200);
+    expect(run.body.human_review_required).toBe(true);
+    expect(run.body.review).toMatchObject({
+      request_id: 'req-review-1',
+      status: 'pending',
+      risk_level: 'high',
+    });
+
+    const pending = await request(app).get('/reviews/pending');
+    expect(pending.status).toBe(200);
+    expect(pending.body.reviews).toHaveLength(1);
+  });
+
+  it('approves a pending review exactly once', async () => {
+    const run = await request(app).post('/agents/run').send({
+      request_id: 'req-review-approve',
+      agent_id: 'compliance_review_agent',
+      objective: 'Review refund and customer impact for chargeback workflow',
+    });
+
+    const reviewId = run.body.review.review_id as string;
+    const approved = await request(app).post(`/reviews/${reviewId}/approve`).send({
+      reviewer: 'ops-lead',
+      decision_note: 'Reviewed evidence and approved follow-up.',
+    });
+
+    expect(approved.status).toBe(200);
+    expect(approved.body.review).toMatchObject({
+      review_id: reviewId,
+      status: 'approved',
+      reviewer: 'ops-lead',
+    });
+
+    const duplicate = await request(app).post(`/reviews/${reviewId}/approve`).send({
+      reviewer: 'ops-lead',
+    });
+    expect(duplicate.status).toBe(400);
+    expect(duplicate.body.error).toContain('already been approved');
+  });
+
+  it('rejects a pending review', async () => {
+    const run = await request(app).post('/agents/run').send({
+      request_id: 'req-review-reject',
+      agent_id: 'compliance_review_agent',
+      objective: 'Review refund and customer impact for chargeback workflow',
+    });
+
+    const reviewId = run.body.review.review_id as string;
+    const rejected = await request(app).post(`/reviews/${reviewId}/reject`).send({
+      reviewer: 'security-reviewer',
+      decision_note: 'Insufficient evidence.',
+    });
+
+    expect(rejected.status).toBe(200);
+    expect(rejected.body.review).toMatchObject({
+      review_id: reviewId,
+      status: 'rejected',
+      reviewer: 'security-reviewer',
+    });
+  });
+
+  it('validates review decision payloads', async () => {
+    const res = await request(app).post('/reviews/missing/approve').send({ reviewer: '' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Invalid review decision payload');
+  });
+});

--- a/tests/unit/agents.routes.test.ts
+++ b/tests/unit/agents.routes.test.ts
@@ -1,0 +1,63 @@
+import request from 'supertest';
+
+beforeAll(() => {
+  process.env.STRIPE_SECRET_KEY = 'sk_test_agents_routes_placeholder';
+  process.env.STRIPE_WEBHOOK_SECRET = 'whsec_agents_routes_placeholder';
+  process.env.GITHUB_WEBHOOK_SECRET = 'github_agents_routes_placeholder';
+  process.env.LOG_LEVEL = 'silent';
+});
+
+import app from '../../src/index';
+
+describe('agent routes', () => {
+  it('lists available agents with MCP plans', async () => {
+    const res = await request(app).get('/agents');
+    expect(res.status).toBe(200);
+    expect(res.body.agents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          agent_id: 'revenue_ops_agent',
+          mcp_plan: expect.any(Array),
+        }),
+        expect.objectContaining({
+          agent_id: 'compliance_review_agent',
+          mcp_plan: expect.any(Array),
+        }),
+      ]),
+    );
+  });
+
+  it('runs an agent and returns telemetry plus MCP plan', async () => {
+    const res = await request(app).post('/agents/run').send({
+      request_id: 'req-http-agent-1',
+      agent_id: 'revenue_ops_agent',
+      objective: 'Summarize webhook event classification for recent health check',
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      request_id: 'req-http-agent-1',
+      agent_id: 'revenue_ops_agent',
+      risk_level: 'low',
+      human_review_required: false,
+    });
+    expect(res.body.mcp_plan).toEqual(expect.any(Array));
+    expect(res.body.telemetry.input_chars).toBeGreaterThan(0);
+    expect(res.body.telemetry.mcp_plan_steps).toBe(res.body.mcp_plan.length);
+  });
+
+  it('rejects invalid agent payloads', async () => {
+    const res = await request(app).post('/agents/run').send({ agent_id: '' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Invalid agent run payload');
+  });
+
+  it('returns 400 for unknown agents', async () => {
+    const res = await request(app).post('/agents/run').send({
+      agent_id: 'does_not_exist',
+      objective: 'Do something',
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('Unknown agent_id');
+  });
+});

--- a/tests/unit/agents.runtime.test.ts
+++ b/tests/unit/agents.runtime.test.ts
@@ -1,0 +1,56 @@
+import { evaluateGuardrails } from '../../src/agents/guardrails';
+import { selectModelProfile } from '../../src/agents/modelRouter';
+import { loadAgentManifest, loadAgentManifests, loadModelRoutingPolicy } from '../../src/agents/registry';
+import { runAgent } from '../../src/agents/runner';
+
+describe('agent runtime', () => {
+  it('loads agent manifests from repository JSON files', () => {
+    const agents = loadAgentManifests();
+    expect(agents.length).toBeGreaterThanOrEqual(2);
+    expect(agents.map((agent) => agent.agent_id)).toEqual(
+      expect.arrayContaining(['revenue_ops_agent', 'compliance_review_agent']),
+    );
+  });
+
+  it('throws for an unknown agent id', () => {
+    expect(() => loadAgentManifest('missing_agent')).toThrow('Unknown agent_id');
+  });
+
+  it('routes customer-impact objectives to the compliance profile', () => {
+    const policy = loadModelRoutingPolicy();
+    const selected = selectModelProfile('refund customer after payment dispute', policy);
+    expect(selected.profile_id).toBe('compliance_strict');
+  });
+
+  it('detects and redacts secret-like language', () => {
+    const result = evaluateGuardrails({
+      agent_id: 'revenue_ops_agent',
+      objective: 'Investigate webhook failure with api_key in logs',
+    });
+    expect(result.findings.map((finding) => finding.rule_id)).toContain('secret_exposure');
+    expect(result.redactions).toContain('secret_like_value');
+  });
+
+  it('runs revenue ops agent with low-risk output', () => {
+    const result = runAgent({
+      request_id: 'req-agent-1',
+      agent_id: 'revenue_ops_agent',
+      objective: 'Summarize webhook health check status',
+    });
+    expect(result.request_id).toBe('req-agent-1');
+    expect(result.agent_id).toBe('revenue_ops_agent');
+    expect(result.model_profile).toBe('fast_classifier');
+    expect(result.risk_level).toBe('low');
+    expect(result.human_review_required).toBe(false);
+  });
+
+  it('requires human review for refund/customer-impact requests', () => {
+    const result = runAgent({
+      agent_id: 'compliance_review_agent',
+      objective: 'Review refund and customer impact for chargeback workflow',
+    });
+    expect(result.risk_level).toBe('high');
+    expect(result.human_review_required).toBe(true);
+    expect(result.status).toBe('requires_human_review');
+  });
+});

--- a/tests/unit/index.envFallbacks.test.ts
+++ b/tests/unit/index.envFallbacks.test.ts
@@ -1,20 +1,11 @@
 /**
  * tests/unit/index.envFallbacks.test.ts
  *
- * Exercises the `??` / `||` env-var fallback branches in src/index.ts that
- * fire only when the corresponding environment variable is absent:
- *   - LOG_LEVEL fallback to 'info' (line 13)
- *   - PORT fallback to 3000 (line 23)
- *   - CORS_ORIGIN fallback to 'http://localhost:3000' (line 58)
- *   - npm_package_version fallback to '1.0.0' (line 70)
- *   - status/statusCode fallback chain in error handler (lines 82–83)
- *
- * We reload the app inside jest.isolateModules() with the relevant env vars
- * cleared so the fallback side of each binary expression is taken.
+ * Exercises env-var fallback branches and app-level runtime metadata.
  */
 
-import request from 'supertest';
 import type { Application } from 'express';
+import request from 'supertest';
 
 describe('src/index.ts env-var fallback branches', () => {
   const originalEnv = { ...process.env };
@@ -27,9 +18,7 @@ describe('src/index.ts env-var fallback branches', () => {
     process.env = { ...originalEnv };
   });
 
-  it('boots with default LOG_LEVEL, PORT, CORS_ORIGIN, and version when env is bare', async () => {
-    // Keep webhook secrets so module-load requireEnv() doesn't throw, but
-    // strip everything else to force the fallback branches.
+  function loadAppWithBareEnv(): Application {
     process.env = {
       ...originalEnv,
       STRIPE_SECRET_KEY: 'sk_test_bare_env',
@@ -41,45 +30,68 @@ describe('src/index.ts env-var fallback branches', () => {
     delete process.env.CORS_ORIGIN;
     delete process.env.npm_package_version;
 
-    // We have to avoid app.listen actually binding — but src/index.ts calls
-    // listen unconditionally on import. Spy on net to suppress the bind side
-    // effect: silence the logger and rely on PORT=0 semantics if we did set
-    // it. Since we removed PORT, listen('3000') will try to bind. Stub it.
     let appInst: Application | undefined;
-    await new Promise<void>((resolve) => {
-      jest.isolateModules(() => {
-        // Stub express.Application.prototype.listen to a no-op for this load.
-        // eslint-disable-next-line @typescript-eslint/no-var-requires
-        const express = require('express') as typeof import('express');
-        // eslint-disable-next-line @typescript-eslint/unbound-method, @typescript-eslint/no-explicit-any
-        const origListen = (express.application as any).listen;
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (express.application as any).listen = function (...args: unknown[]) {
-          // Call the callback (last arg if it's a function) without binding
-          const cb = args[args.length - 1];
-          if (typeof cb === 'function') {
-            (cb as () => void)();
-          }
-          return { close: () => undefined };
-        };
-        // eslint-disable-next-line @typescript-eslint/no-var-requires
-        const mod = require('../../src/index') as { default: Application };
-        appInst = mod.default;
-        // restore listen
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (express.application as any).listen = origListen;
-        resolve();
-      });
+    jest.isolateModules(() => {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const mod = require('../../src/index') as { default: Application };
+      appInst = mod.default;
     });
 
-    expect(appInst).toBeDefined();
+    if (!appInst) {
+      throw new Error('App failed to load');
+    }
 
-    // Hit GET / to verify the version fallback was used in the response.
-    const res = await request(appInst as Application).get('/');
+    return appInst;
+  }
+
+  it('boots with default LOG_LEVEL, PORT, CORS_ORIGIN, and version when env is bare', async () => {
+    const appInst = loadAppWithBareEnv();
+    const res = await request(appInst).get('/');
     expect(res.status).toBe(200);
     expect(res.body).toMatchObject({
       name: 'openclaw-revenue-engine',
       version: '1.0.0',
+      readiness: '/ready',
     });
+  });
+
+  it('returns health metadata', async () => {
+    const appInst = loadAppWithBareEnv();
+    const res = await request(appInst).get('/health');
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      status: 'ok',
+      service: 'openclaw-revenue-engine',
+      version: '1.0.0',
+    });
+    expect(res.body.timestamp).toEqual(expect.any(String));
+  });
+
+  it('returns readiness metadata', async () => {
+    const appInst = loadAppWithBareEnv();
+    const res = await request(appInst).get('/ready');
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      status: 'ready',
+      service: 'openclaw-revenue-engine',
+      dependencies: {
+        stripeWebhook: 'lazy-configured',
+        githubWebhook: 'lazy-configured',
+      },
+    });
+  });
+
+  it('propagates inbound x-request-id', async () => {
+    const appInst = loadAppWithBareEnv();
+    const res = await request(appInst).get('/health').set('x-request-id', 'req-test-123');
+    expect(res.status).toBe(200);
+    expect(res.headers['x-request-id']).toBe('req-test-123');
+  });
+
+  it('generates x-request-id when one is absent', async () => {
+    const appInst = loadAppWithBareEnv();
+    const res = await request(appInst).get('/health');
+    expect(res.status).toBe(200);
+    expect(res.headers['x-request-id']).toEqual(expect.any(String));
   });
 });

--- a/tests/unit/index.errorHandler.test.ts
+++ b/tests/unit/index.errorHandler.test.ts
@@ -2,20 +2,10 @@
  * tests/unit/index.errorHandler.test.ts
  *
  * Exercises the global error-handling middleware in src/index.ts.
- * The handler has three exit branches based on status code:
- *   - 413 → { error: 'Payload Too Large' }
- *   - other 4xx → { error: err.message || 'Bad Request' }
- *   - everything else → 500 + { error: 'Internal Server Error' }
- *
- * The 413 branch is already exercised by the performance suite's oversized
- * payload test. The 4xx and 500 branches are otherwise unreachable through
- * normal routes, so we mount a tiny throwing route on the live app to drive
- * them. This also exercises the `?? statusCode ?? 500` fallback chain and
- * the `err.message || 'Bad Request'` short-circuit.
  */
 
+import express, { NextFunction, Request, Response } from 'express';
 import request from 'supertest';
-import express, { Request, Response, NextFunction } from 'express';
 
 beforeAll(() => {
   process.env.STRIPE_SECRET_KEY = 'sk_test_err_handler_placeholder';
@@ -26,25 +16,19 @@ beforeAll(() => {
 
 import app from '../../src/index';
 
-/**
- * Build a throwaway Express app whose only purpose is to forward errors into
- * the same global error-handling middleware as the production app. We extract
- * the final error-handler from `app` and remount it on a fresh app so we can
- * inject arbitrary errors without polluting the main app's route table.
- */
 function makeErrorApp(err: unknown) {
   const sub = express();
+  sub.use((_req: Request, res: Response, next: NextFunction) => {
+    res.locals.requestId = 'test-request-id';
+    next();
+  });
   sub.get('/boom', (_req: Request, _res: Response, next: NextFunction) => {
     next(err);
   });
 
-  // Reuse the global error handler from the real app. Express stores error
-  // middleware as functions with arity 4 on `app._router.stack`.
   type Layer = { handle: (...args: unknown[]) => unknown };
   const stack = (app as unknown as { _router: { stack: Layer[] } })._router.stack;
-  const errorLayer = stack.find(
-    (l) => typeof l.handle === 'function' && l.handle.length === 4
-  );
+  const errorLayer = stack.find((layer) => typeof layer.handle === 'function' && layer.handle.length === 4);
   if (!errorLayer) {
     throw new Error('Could not locate global error middleware on app');
   }
@@ -57,41 +41,41 @@ describe('global error handler — status code branches', () => {
     const err = Object.assign(new Error('request entity too large'), { status: 413 });
     const res = await request(makeErrorApp(err)).get('/boom');
     expect(res.status).toBe(413);
-    expect(res.body).toEqual({ error: 'Payload Too Large' });
+    expect(res.body).toEqual({ error: 'Payload Too Large', requestId: 'test-request-id' });
   });
 
-  it('returns 413 when the error uses statusCode (not status)', async () => {
+  it('returns 413 when the error uses statusCode instead of status', async () => {
     const err = Object.assign(new Error('PayloadTooLargeError'), { statusCode: 413 });
     const res = await request(makeErrorApp(err)).get('/boom');
     expect(res.status).toBe(413);
-    expect(res.body).toEqual({ error: 'Payload Too Large' });
+    expect(res.body).toEqual({ error: 'Payload Too Large', requestId: 'test-request-id' });
   });
 
   it('returns the supplied 4xx status with err.message for client errors', async () => {
     const err = Object.assign(new Error('bad input'), { status: 422 });
     const res = await request(makeErrorApp(err)).get('/boom');
     expect(res.status).toBe(422);
-    expect(res.body).toEqual({ error: 'bad input' });
+    expect(res.body).toEqual({ error: 'bad input', requestId: 'test-request-id' });
   });
 
-  it('falls back to "Bad Request" when err.message is empty on a 4xx', async () => {
+  it('falls back to Bad Request when err.message is empty on a 4xx', async () => {
     const err = Object.assign(new Error(''), { status: 400 });
     const res = await request(makeErrorApp(err)).get('/boom');
     expect(res.status).toBe(400);
-    expect(res.body).toEqual({ error: 'Bad Request' });
+    expect(res.body).toEqual({ error: 'Bad Request', requestId: 'test-request-id' });
   });
 
   it('returns 500 + Internal Server Error for errors without a status', async () => {
     const err = new Error('unexpected blowup');
     const res = await request(makeErrorApp(err)).get('/boom');
     expect(res.status).toBe(500);
-    expect(res.body).toEqual({ error: 'Internal Server Error' });
+    expect(res.body).toEqual({ error: 'Internal Server Error', requestId: 'test-request-id' });
   });
 
   it('treats explicit 5xx errors as Internal Server Error', async () => {
     const err = Object.assign(new Error('db down'), { status: 503 });
     const res = await request(makeErrorApp(err)).get('/boom');
     expect(res.status).toBe(500);
-    expect(res.body).toEqual({ error: 'Internal Server Error' });
+    expect(res.body).toEqual({ error: 'Internal Server Error', requestId: 'test-request-id' });
   });
 });

--- a/tests/unit/mcp.runtime.test.ts
+++ b/tests/unit/mcp.runtime.test.ts
@@ -1,0 +1,62 @@
+import request from 'supertest';
+
+import { loadAgentManifest } from '../../src/agents/registry';
+import { planMcpUsage } from '../../src/mcp/planner';
+import { getMcpServer, viewMcpServers } from '../../src/mcp/registry';
+
+beforeAll(() => {
+  process.env.STRIPE_SECRET_KEY = 'sk_test_mcp_routes_placeholder';
+  process.env.STRIPE_WEBHOOK_SECRET = 'whsec_mcp_routes_placeholder';
+  process.env.GITHUB_WEBHOOK_SECRET = 'github_mcp_routes_placeholder';
+  process.env.LOG_LEVEL = 'silent';
+});
+
+import app from '../../src/index';
+
+describe('MCP runtime', () => {
+  it('loads MCP inventory and redacts command execution details from views', () => {
+    const servers = viewMcpServers();
+    expect(servers.length).toBeGreaterThanOrEqual(2);
+    expect(servers[0]).toEqual(
+      expect.objectContaining({
+        id: expect.any(String),
+        configured: expect.any(Boolean),
+        missing_env: expect.any(Array),
+      }),
+    );
+    expect(servers[0]).not.toHaveProperty('command');
+  });
+
+  it('throws for unknown MCP servers', () => {
+    expect(() => getMcpServer('missing')).toThrow('Unknown MCP server');
+  });
+
+  it('plans MCP usage for revenue ops agent without enabling secret reads', () => {
+    const agent = loadAgentManifest('revenue_ops_agent');
+    const plan = planMcpUsage(agent);
+    expect(plan.length).toBe(agent.allowed_tools.length);
+    expect(plan.every((step) => step.capability !== 'secret_read')).toBe(true);
+  });
+
+  it('lists MCP servers over HTTP', async () => {
+    const res = await request(app).get('/mcp/servers');
+    expect(res.status).toBe(200);
+    expect(res.body.servers).toEqual(expect.any(Array));
+    expect(res.body.servers[0]).not.toHaveProperty('command');
+  });
+
+  it('returns one MCP server by id over HTTP', async () => {
+    const res = await request(app).get('/mcp/servers/filesystem_docs');
+    expect(res.status).toBe(200);
+    expect(res.body.server).toMatchObject({
+      id: 'filesystem_docs',
+      blocked_capabilities: expect.arrayContaining(['secret_read']),
+    });
+  });
+
+  it('returns 404 for unknown MCP server over HTTP', async () => {
+    const res = await request(app).get('/mcp/servers/missing');
+    expect(res.status).toBe(404);
+    expect(res.body.error).toContain('Unknown MCP server');
+  });
+});

--- a/tests/unit/webhook.fallbacks.test.ts
+++ b/tests/unit/webhook.fallbacks.test.ts
@@ -1,32 +1,31 @@
 /**
  * tests/unit/webhook.fallbacks.test.ts
  *
- * Targets the small `??` / `||` fallback branches in the webhook handlers
- * that are not exercised by the main routing tests:
- *   - requireEnv throws when its var is unset (module-load guard)
+ * Targets fallback branches in the webhook handlers:
+ *   - missing provider env vars fail at request time with controlled 500 responses
  *   - stripe: invoice.id ?? 'unknown', next_payment_attempt ?? 'none'
- *   - stripe: non-Error catch path → 'Unknown error'
+ *   - stripe: non-Error catch path -> 'Unknown error'
  *   - github: array-valued event/delivery headers
- *   - github: object body (already-parsed by upstream JSON middleware)
- *   - github: missing delivery header on signature mismatch (delivery ?? 'unknown')
- *   - github: non-Error catch path → 'Unknown error'
+ *   - github: object body handling and missing delivery fallback
+ *   - github: non-Error catch path -> 'Unknown error'
  */
 
-import type { Request, Response } from 'express';
 import crypto from 'crypto';
+import type { Request, Response } from 'express';
+
 import {
   buildGitHubPayload,
   buildStripePayload,
   GITHUB_TEST_WEBHOOK_SECRET,
-  STRIPE_TEST_WEBHOOK_SECRET,
   mockResponse,
+  STRIPE_TEST_WEBHOOK_SECRET,
 } from '../helpers/fixtures';
 
 // ---------------------------------------------------------------------------
-// requireEnv guards — module load fails when required env vars are missing
+// Request-time configuration guards
 // ---------------------------------------------------------------------------
 
-describe('requireEnv guards at module load', () => {
+describe('webhook configuration guards at request time', () => {
   const originalEnv = { ...process.env };
 
   afterEach(() => {
@@ -34,34 +33,75 @@ describe('requireEnv guards at module load', () => {
     jest.resetModules();
   });
 
-  it('stripe.webhook throws if STRIPE_SECRET_KEY is missing', () => {
+  it('stripe.webhook returns 500 if STRIPE_SECRET_KEY is missing', () => {
     delete process.env.STRIPE_SECRET_KEY;
-    expect(() => {
-      jest.isolateModules(() => {
-        // eslint-disable-next-line @typescript-eslint/no-var-requires
-        require('../../src/webhooks/stripe.webhook');
-      });
-    }).toThrow(/STRIPE_SECRET_KEY/);
+    process.env.STRIPE_WEBHOOK_SECRET = STRIPE_TEST_WEBHOOK_SECRET;
+
+    jest.isolateModules(() => {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const mod = require('../../src/webhooks/stripe.webhook') as typeof import('../../src/webhooks/stripe.webhook');
+      const { body, signature } = buildStripePayload('evt_missing_secret', {}, STRIPE_TEST_WEBHOOK_SECRET);
+      const captured = mockResponse();
+      const errSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+      mod.stripeWebhookHandler(
+        { body, headers: { 'stripe-signature': signature } } as unknown as Request,
+        captured.res as Response,
+      );
+
+      expect(captured.statusCode).toBe(500);
+      expect(captured.body).toMatchObject({ error: 'Stripe webhook is not configured' });
+      errSpy.mockRestore();
+    });
   });
 
-  it('stripe.webhook throws if STRIPE_WEBHOOK_SECRET is missing', () => {
+  it('stripe.webhook returns 500 if STRIPE_WEBHOOK_SECRET is missing', () => {
+    process.env.STRIPE_SECRET_KEY = 'sk_test_missing_webhook_secret';
     delete process.env.STRIPE_WEBHOOK_SECRET;
-    expect(() => {
-      jest.isolateModules(() => {
-        // eslint-disable-next-line @typescript-eslint/no-var-requires
-        require('../../src/webhooks/stripe.webhook');
-      });
-    }).toThrow(/STRIPE_WEBHOOK_SECRET/);
+
+    jest.isolateModules(() => {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const mod = require('../../src/webhooks/stripe.webhook') as typeof import('../../src/webhooks/stripe.webhook');
+      const { body, signature } = buildStripePayload('evt_missing_webhook_secret', {}, STRIPE_TEST_WEBHOOK_SECRET);
+      const captured = mockResponse();
+      const errSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+      mod.stripeWebhookHandler(
+        { body, headers: { 'stripe-signature': signature } } as unknown as Request,
+        captured.res as Response,
+      );
+
+      expect(captured.statusCode).toBe(500);
+      expect(captured.body).toMatchObject({ error: 'Stripe webhook is not configured' });
+      errSpy.mockRestore();
+    });
   });
 
-  it('github.webhook throws if GITHUB_WEBHOOK_SECRET is missing', () => {
+  it('github.webhook returns 500 if GITHUB_WEBHOOK_SECRET is missing', () => {
     delete process.env.GITHUB_WEBHOOK_SECRET;
-    expect(() => {
-      jest.isolateModules(() => {
-        // eslint-disable-next-line @typescript-eslint/no-var-requires
-        require('../../src/webhooks/github.webhook');
-      });
-    }).toThrow(/GITHUB_WEBHOOK_SECRET/);
+
+    jest.isolateModules(() => {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const mod = require('../../src/webhooks/github.webhook') as typeof import('../../src/webhooks/github.webhook');
+      const built = buildGitHubPayload('ping', {}, GITHUB_TEST_WEBHOOK_SECRET);
+      const captured = mockResponse();
+      const errSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+      mod.githubWebhookHandler(
+        {
+          body: built.body,
+          headers: {
+            'x-hub-signature-256': built.signature,
+            'x-github-event': 'ping',
+          },
+        } as unknown as Request,
+        captured.res as Response,
+      );
+
+      expect(captured.statusCode).toBe(500);
+      expect(captured.body).toMatchObject({ error: 'GitHub webhook is not configured' });
+      errSpy.mockRestore();
+    });
   });
 });
 
@@ -70,7 +110,6 @@ describe('requireEnv guards at module load', () => {
 // ---------------------------------------------------------------------------
 
 describe('stripeWebhookHandler — invoice fallbacks and non-Error catch', () => {
-  // Mock the stripe SDK so constructEvent is controllable
   const mockConstructEvent = jest.fn();
 
   jest.doMock('stripe', () => {
@@ -103,7 +142,6 @@ describe('stripeWebhookHandler — invoice fallbacks and non-Error catch', () =>
     mockConstructEvent.mockReturnValueOnce({
       id: 'evt_fallback_1',
       type: 'invoice.payment_succeeded',
-      // id is undefined to hit the `?? 'unknown'` branch
       data: { object: { customer: 'cus_x', amount_paid: 100, currency: 'usd' } },
     });
     const captured = mockResponse();
@@ -118,7 +156,7 @@ describe('stripeWebhookHandler — invoice fallbacks and non-Error catch', () =>
     mockConstructEvent.mockReturnValueOnce({
       id: 'evt_fallback_2',
       type: 'invoice.payment_failed',
-      data: { object: { id: 'in_x', customer: 'cus_x' } }, // no next_payment_attempt
+      data: { object: { id: 'in_x', customer: 'cus_x' } },
     });
     const captured = mockResponse();
     stripeWebhookHandler(req(), captured.res as Response);
@@ -146,7 +184,6 @@ describe('stripeWebhookHandler — invoice fallbacks and non-Error catch', () =>
       id: 'evt_fallback_3',
       type: 'customer.subscription.created',
       data: {
-        // accessing .id on this proxy throws a non-Error string
         object: new Proxy({}, {
           get() {
             // eslint-disable-next-line @typescript-eslint/no-throw-literal
@@ -197,16 +234,6 @@ describe('githubWebhookHandler — header normalisation and fallbacks', () => {
   });
 
   it('accepts an already-parsed object body (non-Buffer)', () => {
-    // When the body is already a plain object (e.g. an upstream JSON parser ran),
-    // the handler must skip JSON.parse and use the object directly. We must
-    // also compute the signature over the JSON form the handler sees: but with
-    // an object body, signature verification works on `body as Buffer` cast and
-    // will fail timing-safe equality, so we expect 401 here. The branch we
-    // need is the `instanceof Buffer` ternary, which fires before verification
-    // when handler tries to extract payload — but actually verification runs
-    // first. Instead, drive the non-Buffer branch by supplying a Buffer that
-    // matches signature; then assert success. The conditional that flips on
-    // body type is hit during the payload extraction phase.
     const payload = { ref: 'refs/heads/main', repository: { full_name: 'a/b' }, pusher: { name: 'x' } };
     const bodyBuf = Buffer.from(JSON.stringify(payload), 'utf8');
     const sig = `sha256=${crypto.createHmac('sha256', GITHUB_TEST_WEBHOOK_SECRET).update(bodyBuf).digest('hex')}`;
@@ -232,7 +259,6 @@ describe('githubWebhookHandler — header normalisation and fallbacks', () => {
       headers: {
         'x-hub-signature-256': 'sha256=deadbeef00000000000000000000000000000000000000000000000000000000',
         'x-github-event': 'push',
-        // x-github-delivery intentionally omitted to drive the `?? 'unknown'` branch
       },
     } as unknown as Request;
     const errSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
@@ -260,23 +286,11 @@ describe('githubWebhookHandler — header normalisation and fallbacks', () => {
   });
 
   it('returns 500 with generic message when handler throws a non-Error', () => {
-    // Build a payload whose `repository` field is a getter that throws a string.
-    // The handler's catch branch then hits the `err instanceof Error` fallback.
-    // We need the signature to verify, so we sign the JSON.stringify form.
-    // JSON.stringify will invoke the getter and throw — so instead, sign a
-    // valid serialised body and rely on the fact that the handler parses the
-    // body itself with JSON.parse. Supply a body that parses to an object
-    // *after* signature check but whose property accesses throw a non-Error.
-    // The simplest: an array body — push handler accesses .repository.full_name
-    // on undefined, which throws a TypeError (Error instance). To force a
-    // non-Error throw, we can monkey-patch JSON.parse for this call only.
     const goodBody = Buffer.from(JSON.stringify({ ref: 'refs/heads/main' }), 'utf8');
     const sig = `sha256=${crypto.createHmac('sha256', GITHUB_TEST_WEBHOOK_SECRET).update(goodBody).digest('hex')}`;
     const origParse = JSON.parse;
     const parseSpy = jest.spyOn(JSON, 'parse').mockImplementation((_s: string) => {
-      // Restore after first call so we don't break the rest of Jest.
       JSON.parse = origParse;
-      // Return an object whose `repository` access throws a non-Error string.
       return new Proxy({ ref: 'refs/heads/main' }, {
         get(t, k) {
           if (k === 'repository') {


### PR DESCRIPTION
## Summary
- repair malformed `package.json` scripts block
- switch runtime entrypoint to `dist/server.js`
- split Express app creation from server startup
- add `src/server.ts` bootstrap entrypoint
- avoid webhook env-var failures at module import time
- return controlled webhook configuration / JSON errors instead of crashing imports
- add safer GitHub webhook payload validation

## Root causes found
1. `package.json` was invalid JSON because a placeholder lint script was inserted into the middle of the scripts object.
2. `src/index.ts` started the HTTP server at import time, which makes Jest rely on `forceExit` and leaves an avoidable open-handle pattern.
3. Stripe and GitHub webhook modules required secrets at module load, making app imports fail before tests or health checks could run when webhook secrets were missing.
4. GitHub webhook JSON parsing and payload field access could throw uncontrolled exceptions.

## Solution code
- `src/index.ts` now exports `createApp()` and a default app instance without calling `listen()`.
- `src/server.ts` owns process startup.
- webhook handlers now resolve secrets inside request handling and return explicit configuration errors.
- GitHub event handlers now validate required nested payload records before reading fields.

## Validation expectations
- `npm ci` can parse the package manifest again.
- `npm run type-check` should compile both app and server entrypoints.
- `npm run test:*` no longer depends on import-time server startup.
- Existing webhook tests should keep passing with safer env handling.
