### PR TITLE
feat(revenue-engine): add clean agent MCP control plane

### DIFF
--- a/agents/compliance-review-agent.json
+++ b/agents/compliance-review-agent.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": "1.0.0",
+  "agent_id": "compliance_review_agent",
+  "name": "Compliance Review Agent",
+  "description": "Reviews outbound operational summaries and webhook-derived insights for privacy, payment, and security risk before delivery.",
+  "model_profile": "compliance_strict",
+  "allowed_tools": [
+    "scan_for_secrets",
+    "scan_for_pii",
+    "validate_claims",
+    "draft_remediation_notes"
+  ],
+  "inputs": [
+    "candidate_summary",
+    "event_metadata",
+    "delivery_context"
+  ],
+  "outputs": [
+    "approval_status",
+    "blocking_issues",
+    "required_redactions",
+    "revision_notes"
+  ],
+  "guardrails": {
+    "block_secret_exposure": true,
+    "block_payment_data_exposure": true,
+    "block_unverified_financial_claims": true,
+    "require_human_review_for_customer_impact": true
+  },
+  "success_criteria": [
+    "Blocks sensitive data leakage.",
+    "Distinguishes low-risk wording edits from delivery blockers.",
+    "Returns concrete remediation instructions."
+  ]
+}

--- a/agents/revenue-ops-agent.json
+++ b/agents/revenue-ops-agent.json
@@ -1,0 +1,36 @@
+{
+  "schema_version": "1.0.0",
+  "agent_id": "revenue_ops_agent",
+  "name": "Revenue Operations Agent",
+  "description": "Analyzes subscription, invoice, webhook, and usage events to recommend operational actions for the revenue engine.",
+  "model_profile": "reasoning_default",
+  "allowed_tools": [
+    "read_runtime_health",
+    "read_webhook_events",
+    "summarize_billing_anomalies",
+    "draft_operator_runbook"
+  ],
+  "inputs": [
+    "health_status",
+    "webhook_event_summary",
+    "billing_error_summary",
+    "usage_metric_summary"
+  ],
+  "outputs": [
+    "operational_summary",
+    "risk_level",
+    "recommended_actions",
+    "human_review_required"
+  ],
+  "guardrails": {
+    "never_execute_payments": true,
+    "never_modify_customer_records": true,
+    "require_human_review_for_refunds": true,
+    "redact_secrets": true
+  },
+  "success_criteria": [
+    "Classifies billing anomalies with clear severity.",
+    "Preserves uncertainty instead of inventing root causes.",
+    "Suggests reversible next steps before destructive actions."
+  ]
+}

--- a/config/model-routing.json
+++ b/config/model-routing.json
@@ -1,0 +1,40 @@
+{
+  "schema_version": "1.0.0",
+  "default_profile": "reasoning_default",
+  "profiles": {
+    "reasoning_default": {
+      "purpose": "General operational reasoning, anomaly summaries, and runbook drafting.",
+      "preferred_model_family": "reasoning",
+      "temperature": 0.2,
+      "max_output_tokens": 1200,
+      "requires_citations": false,
+      "human_review_required": false
+    },
+    "compliance_strict": {
+      "purpose": "Privacy, payment, security, and external-delivery review.",
+      "preferred_model_family": "reasoning",
+      "temperature": 0,
+      "max_output_tokens": 900,
+      "requires_citations": true,
+      "human_review_required": true
+    },
+    "fast_classifier": {
+      "purpose": "Low-risk event classification and routing.",
+      "preferred_model_family": "small_fast",
+      "temperature": 0,
+      "max_output_tokens": 300,
+      "requires_citations": false,
+      "human_review_required": false
+    }
+  },
+  "routing_rules": [
+    {
+      "match": "refund|chargeback|payment dispute|customer impact",
+      "profile": "compliance_strict"
+    },
+    {
+      "match": "webhook event classification|health check|routing",
+      "profile": "fast_classifier"
+    }
+  ]
+}

--- a/mcp/servers.json
+++ b/mcp/servers.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": "1.0.0",
+  "servers": [
+    {
+      "id": "github_context",
+      "name": "GitHub Context MCP",
+      "transport": "stdio",
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "required_env": ["GITHUB_TOKEN"],
+      "allowed_capabilities": ["repo_read", "issue_read", "pull_request_read"],
+      "blocked_capabilities": ["repo_write", "secret_read", "workflow_write"],
+      "purpose": "Read-only repository context for agent analysis and runbook generation."
+    },
+    {
+      "id": "filesystem_docs",
+      "name": "Filesystem Docs MCP",
+      "transport": "stdio",
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "./docs", "./agents", "./config"],
+      "required_env": [],
+      "allowed_capabilities": ["file_read"],
+      "blocked_capabilities": ["file_write", "secret_read"],
+      "purpose": "Read-only local documentation and agent policy context."
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openclaw-revenue-engine",
   "version": "1.0.0",
   "description": "Self-hosted revenue engine for OpenClaw agents",
-  "main": "dist/index.js",
+  "main": "dist/server.js",
   "scripts": {
     "lint": "eslint . --ext .ts",
     "type-check": "tsc --noEmit",
@@ -14,8 +14,8 @@
     "build": "tsc",
     "prebuild": "npm run clean",
     "clean": "rm -rf dist",
-    "start": "node dist/index.js",
-    "dev": "ts-node src/index.ts"
+    "start": "node dist/server.js",
+    "dev": "ts-node src/server.ts"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/src/agents/auditLog.ts
+++ b/src/agents/auditLog.ts
@@ -1,0 +1,56 @@
+import { AgentRunInput, AgentRunResult } from './types';
+
+export interface AgentAuditRecord {
+  request_id: string;
+  agent_id: string;
+  agent_name: string;
+  model_profile: string;
+  risk_level: AgentRunResult['risk_level'];
+  status: AgentRunResult['status'];
+  human_review_required: boolean;
+  findings_count: number;
+  redactions_count: number;
+  mcp_plan_steps: number;
+  objective: string;
+  event_summary?: string;
+  created_at: string;
+  result: AgentRunResult;
+}
+
+const MAX_AUDIT_RECORDS = 500;
+const auditRecords: AgentAuditRecord[] = [];
+
+export function recordAgentRun(input: AgentRunInput, result: AgentRunResult): AgentAuditRecord {
+  const record: AgentAuditRecord = {
+    request_id: result.request_id,
+    agent_id: result.agent_id,
+    agent_name: result.agent_name,
+    model_profile: result.model_profile,
+    risk_level: result.risk_level,
+    status: result.status,
+    human_review_required: result.human_review_required,
+    findings_count: result.findings.length,
+    redactions_count: result.redactions.length,
+    mcp_plan_steps: result.mcp_plan.length,
+    objective: input.objective,
+    event_summary: input.event_summary,
+    created_at: new Date().toISOString(),
+    result,
+  };
+
+  auditRecords.unshift(record);
+  if (auditRecords.length > MAX_AUDIT_RECORDS) auditRecords.length = MAX_AUDIT_RECORDS;
+  return record;
+}
+
+export function listAgentRuns(limit = 50): AgentAuditRecord[] {
+  return auditRecords.slice(0, Math.max(0, Math.min(limit, MAX_AUDIT_RECORDS)));
+}
+
+export function getAgentRun(requestId: string): AgentAuditRecord | undefined {
+  return auditRecords.find((record) => record.request_id === requestId);
+}
+
+export function clearAgentAuditLogForTests(): void {
+  auditRecords.length = 0;
+}

--- a/src/agents/guardrails.ts
+++ b/src/agents/guardrails.ts
@@ -1,0 +1,39 @@
+import { AgentRunInput, GuardrailFinding, RiskLevel } from './types';
+
+const SECRET_PATTERN = /(api[_-]?key|secret|token|password|whsec_|sk_live_|sk_test_)/i;
+const PAYMENT_PATTERN = /(card number|cvv|cvc|payment method|bank account|chargeback|refund)/i;
+const CUSTOMER_IMPACT_PATTERN = /(delete customer|modify customer|cancel subscription|refund|downgrade|customer impact)/i;
+
+function finding(rule_id: string, severity: RiskLevel, message: string): GuardrailFinding {
+  return { rule_id, severity, message };
+}
+
+export function evaluateGuardrails(input: AgentRunInput): { findings: GuardrailFinding[]; redactedText: string; redactions: string[] } {
+  const text = [input.objective, input.event_summary, JSON.stringify(input.context ?? {})].join('\n');
+  const findings: GuardrailFinding[] = [];
+  const redactions: string[] = [];
+  let redactedText = text;
+
+  if (SECRET_PATTERN.test(text)) {
+    findings.push(finding('secret_exposure', 'critical', 'Potential secret or credential reference detected.'));
+    redactedText = redactedText.replace(SECRET_PATTERN, '[REDACTED_SECRET]');
+    redactions.push('secret_like_value');
+  }
+
+  if (PAYMENT_PATTERN.test(text)) {
+    findings.push(finding('payment_risk', 'high', 'Payment, refund, or card-related language requires review.'));
+  }
+
+  if (CUSTOMER_IMPACT_PATTERN.test(text)) {
+    findings.push(finding('customer_impact', 'high', 'Customer-impacting action requires human approval.'));
+  }
+
+  return { findings, redactedText, redactions };
+}
+
+export function highestRisk(findings: GuardrailFinding[]): RiskLevel {
+  if (findings.some((item) => item.severity === 'critical')) return 'critical';
+  if (findings.some((item) => item.severity === 'high')) return 'high';
+  if (findings.some((item) => item.severity === 'medium')) return 'medium';
+  return 'low';
+}

--- a/src/agents/modelRouter.ts
+++ b/src/agents/modelRouter.ts
@@ -1,0 +1,34 @@
+import { ModelProfile, ModelRoutingPolicy } from './types';
+
+export interface SelectedModelProfile {
+  profile_id: string;
+  profile: ModelProfile;
+  matched_rule?: string;
+}
+
+export function selectModelProfile(
+  objective: string,
+  policy: ModelRoutingPolicy,
+  fallbackProfile?: string,
+): SelectedModelProfile {
+  const normalized = objective.toLowerCase();
+
+  for (const rule of policy.routing_rules) {
+    const pattern = new RegExp(rule.match, 'i');
+    if (pattern.test(normalized)) {
+      const profile = policy.profiles[rule.profile];
+      if (!profile) {
+        throw new Error(`Model routing rule references missing profile: ${rule.profile}`);
+      }
+      return { profile_id: rule.profile, profile, matched_rule: rule.match };
+    }
+  }
+
+  const profileId = fallbackProfile ?? policy.default_profile;
+  const profile = policy.profiles[profileId];
+  if (!profile) {
+    throw new Error(`Missing model profile: ${profileId}`);
+  }
+
+  return { profile_id: profileId, profile };
+}

--- a/src/agents/registry.ts
+++ b/src/agents/registry.ts
@@ -1,0 +1,48 @@
+import fs from 'fs';
+import path from 'path';
+
+import { AgentManifest, ModelRoutingPolicy } from './types';
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+
+function readJson<T>(filePath: string): T {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8')) as T;
+}
+
+function assertManifest(value: AgentManifest): AgentManifest {
+  if (!value.agent_id || !value.name || !value.model_profile) {
+    throw new Error('Invalid agent manifest: agent_id, name, and model_profile are required');
+  }
+  if (!Array.isArray(value.allowed_tools) || !Array.isArray(value.inputs) || !Array.isArray(value.outputs)) {
+    throw new Error(`Invalid agent manifest ${value.agent_id}: allowed_tools, inputs, and outputs must be arrays`);
+  }
+  return value;
+}
+
+export function loadAgentManifests(agentDir = path.join(repoRoot, 'agents')): AgentManifest[] {
+  if (!fs.existsSync(agentDir)) return [];
+
+  return fs
+    .readdirSync(agentDir)
+    .filter((file) => file.endsWith('.json'))
+    .sort()
+    .map((file) => assertManifest(readJson<AgentManifest>(path.join(agentDir, file))));
+}
+
+export function loadAgentManifest(agentId: string): AgentManifest {
+  const manifest = loadAgentManifests().find((agent) => agent.agent_id === agentId);
+  if (!manifest) {
+    throw new Error(`Unknown agent_id: ${agentId}`);
+  }
+  return manifest;
+}
+
+export function loadModelRoutingPolicy(
+  policyPath = path.join(repoRoot, 'config', 'model-routing.json'),
+): ModelRoutingPolicy {
+  const policy = readJson<ModelRoutingPolicy>(policyPath);
+  if (!policy.default_profile || !policy.profiles?.[policy.default_profile]) {
+    throw new Error('Invalid model routing policy: default_profile must exist in profiles');
+  }
+  return policy;
+}

--- a/src/agents/runner.ts
+++ b/src/agents/runner.ts
@@ -1,0 +1,81 @@
+import crypto from 'crypto';
+
+import { planMcpUsage } from '../mcp/planner';
+import { evaluateGuardrails, highestRisk } from './guardrails';
+import { selectModelProfile } from './modelRouter';
+import { loadAgentManifest, loadAgentManifests, loadModelRoutingPolicy } from './registry';
+import { AgentRunInput, AgentRunResult, AgentStatus } from './types';
+
+function buildActions(agentId: string, risk: string): string[] {
+  if (agentId === 'compliance_review_agent') {
+    return risk === 'low'
+      ? ['Approve low-risk internal summary.', 'Keep delivery logs for audit traceability.']
+      : ['Block external delivery until findings are remediated.', 'Escalate to a human reviewer.'];
+  }
+
+  return risk === 'low'
+    ? ['Summarize webhook or billing signal.', 'Check recent deployment and provider status.', 'Prepare reversible remediation steps.']
+    : ['Pause destructive action.', 'Collect provider event IDs and request IDs.', 'Route to Compliance Review Agent.'];
+}
+
+function buildSummary(agentName: string, objective: string, risk: string): string {
+  return `${agentName} evaluated the request as ${risk} risk: ${objective}`;
+}
+
+function statusFor(reviewRequired: boolean, findingsCount: number): AgentStatus {
+  if (reviewRequired) return 'requires_human_review';
+  if (findingsCount > 0) return 'blocked';
+  return 'completed';
+}
+
+export function listAgents() {
+  return loadAgentManifests().map((agent) => ({
+    agent_id: agent.agent_id,
+    name: agent.name,
+    description: agent.description,
+    model_profile: agent.model_profile,
+    allowed_tools: agent.allowed_tools,
+    mcp_plan: planMcpUsage(agent),
+  }));
+}
+
+export function runAgent(input: AgentRunInput): AgentRunResult {
+  const manifest = loadAgentManifest(input.agent_id);
+  const policy = loadModelRoutingPolicy();
+  const selectedProfile = selectModelProfile(input.objective, policy, manifest.model_profile);
+  const guardrail = evaluateGuardrails(input);
+  const risk = highestRisk(guardrail.findings);
+  const modelRequiresReview = selectedProfile.profile.human_review_required;
+  const manifestRequiresReview = Boolean(
+    manifest.guardrails.require_human_review_for_refunds
+      || manifest.guardrails.require_human_review_for_customer_impact,
+  );
+  const humanReviewRequired =
+    modelRequiresReview ||
+    (manifestRequiresReview && risk !== 'low') ||
+    risk === 'critical';
+
+  const recommendedActions = buildActions(manifest.agent_id, risk);
+  const mcpPlan = planMcpUsage(manifest);
+
+  return {
+    request_id: input.request_id ?? crypto.randomUUID(),
+    agent_id: manifest.agent_id,
+    agent_name: manifest.name,
+    model_profile: selectedProfile.profile_id,
+    status: statusFor(humanReviewRequired, guardrail.findings.length),
+    risk_level: risk,
+    summary: buildSummary(manifest.name, guardrail.redactedText.split('\n')[0], risk),
+    recommended_actions: recommendedActions,
+    findings: guardrail.findings,
+    redactions: guardrail.redactions,
+    mcp_plan: mcpPlan,
+    human_review_required: humanReviewRequired,
+    telemetry: {
+      input_chars: JSON.stringify(input).length,
+      output_actions: recommendedActions.length,
+      guardrail_findings: guardrail.findings.length,
+      mcp_plan_steps: mcpPlan.length,
+    },
+  };
+}

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -1,0 +1,80 @@
+export type RiskLevel = 'low' | 'medium' | 'high' | 'critical';
+export type AgentStatus = 'completed' | 'blocked' | 'requires_human_review';
+
+export interface AgentManifest {
+  schema_version: string;
+  agent_id: string;
+  name: string;
+  description: string;
+  model_profile: string;
+  allowed_tools: string[];
+  inputs: string[];
+  outputs: string[];
+  guardrails: Record<string, boolean>;
+  success_criteria: string[];
+}
+
+export interface ModelProfile {
+  purpose: string;
+  preferred_model_family: string;
+  temperature: number;
+  max_output_tokens: number;
+  requires_citations: boolean;
+  human_review_required: boolean;
+}
+
+export interface ModelRoutingRule {
+  match: string;
+  profile: string;
+}
+
+export interface ModelRoutingPolicy {
+  schema_version: string;
+  default_profile: string;
+  profiles: Record<string, ModelProfile>;
+  routing_rules: ModelRoutingRule[];
+}
+
+export interface AgentRunInput {
+  request_id?: string;
+  agent_id: string;
+  objective: string;
+  context?: Record<string, unknown>;
+  event_summary?: string;
+}
+
+export interface GuardrailFinding {
+  rule_id: string;
+  severity: RiskLevel;
+  message: string;
+}
+
+export interface AgentMcpUsagePlan {
+  server_id: string;
+  server_name: string;
+  capability: string;
+  purpose: string;
+  safe_to_execute: boolean;
+  blocked_reason?: string;
+}
+
+export interface AgentRunResult {
+  request_id: string;
+  agent_id: string;
+  agent_name: string;
+  model_profile: string;
+  status: AgentStatus;
+  risk_level: RiskLevel;
+  summary: string;
+  recommended_actions: string[];
+  findings: GuardrailFinding[];
+  redactions: string[];
+  mcp_plan: AgentMcpUsagePlan[];
+  human_review_required: boolean;
+  telemetry: {
+    input_chars: number;
+    output_actions: number;
+    guardrail_findings: number;
+    mcp_plan_steps: number;
+  };
+}

--- a/src/config/app.ts
+++ b/src/config/app.ts
@@ -1,0 +1,68 @@
+import { getOptionalEnv } from './env';
+
+function parsePort(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+
+  const port = Number.parseInt(value, 10);
+  if (!Number.isInteger(port) || port < 0 || port > 65_535) {
+    throw new Error(`PORT must be an integer between 0 and 65535, got ${value}`);
+  }
+
+  return port;
+}
+
+function parseBoolean(value: string | undefined, fallback = false): boolean {
+  if (value === undefined) return fallback;
+  return value.toLowerCase() === 'true';
+}
+
+function parsePositiveInteger(value: string | undefined, fallback: number, name: string): number {
+  if (!value) return fallback;
+
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new Error(`${name} must be a positive integer, got ${value}`);
+  }
+
+  return parsed;
+}
+
+export interface AppConfig {
+  serviceName: string;
+  version: string;
+  nodeEnv: string;
+  port: number;
+  logLevel: string;
+  corsOrigin: string;
+  corsCredentials: boolean;
+  jsonBodyLimit: string;
+  globalRateLimit: {
+    windowMs: number;
+    max: number;
+  };
+  webhookRateLimit: {
+    windowMs: number;
+    max: number;
+  };
+}
+
+export function loadAppConfig(): AppConfig {
+  return {
+    serviceName: getOptionalEnv('SERVICE_NAME', 'openclaw-revenue-engine') ?? 'openclaw-revenue-engine',
+    version: getOptionalEnv('npm_package_version', '1.0.0') ?? '1.0.0',
+    nodeEnv: getOptionalEnv('NODE_ENV', 'development') ?? 'development',
+    port: parsePort(process.env.PORT, 3000),
+    logLevel: getOptionalEnv('LOG_LEVEL', 'info') ?? 'info',
+    corsOrigin: getOptionalEnv('CORS_ORIGIN', 'http://localhost:3000') ?? 'http://localhost:3000',
+    corsCredentials: parseBoolean(process.env.CORS_CREDENTIALS),
+    jsonBodyLimit: getOptionalEnv('JSON_BODY_LIMIT', '1mb') ?? '1mb',
+    globalRateLimit: {
+      windowMs: parsePositiveInteger(process.env.GLOBAL_RATE_LIMIT_WINDOW_MS, 60_000, 'GLOBAL_RATE_LIMIT_WINDOW_MS'),
+      max: parsePositiveInteger(process.env.GLOBAL_RATE_LIMIT_MAX, 100, 'GLOBAL_RATE_LIMIT_MAX'),
+    },
+    webhookRateLimit: {
+      windowMs: parsePositiveInteger(process.env.WEBHOOK_RATE_LIMIT_WINDOW_MS, 60_000, 'WEBHOOK_RATE_LIMIT_WINDOW_MS'),
+      max: parsePositiveInteger(process.env.WEBHOOK_RATE_LIMIT_MAX, 30, 'WEBHOOK_RATE_LIMIT_MAX'),
+    },
+  };
+}

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,0 +1,21 @@
+const REQUIRED_ENV_ERROR_PREFIX = 'Missing required environment variable:';
+
+export function getRequiredEnv(key: string): string {
+  const value = process.env[key];
+  if (!value) {
+    throw new Error(`${REQUIRED_ENV_ERROR_PREFIX} ${key}`);
+  }
+  return value;
+}
+
+export function getOptionalEnv(key: string, fallback?: string): string | undefined {
+  return process.env[key] ?? fallback;
+}
+
+export function isMissingRequiredEnvError(error: unknown): boolean {
+  return error instanceof Error && error.message.startsWith(REQUIRED_ENV_ERROR_PREFIX);
+}
+
+export function toErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : 'Unknown error';
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,109 +1,154 @@
 import 'dotenv/config';
 
-import express, { Application, Request, Response, NextFunction } from 'express';
+import crypto from 'crypto';
 import cors from 'cors';
-import helmet from 'helmet';
+import express, { Application, NextFunction, Request, Response } from 'express';
 import rateLimit from 'express-rate-limit';
+import helmet from 'helmet';
 import { createLogger, format, transports } from 'winston';
 
-import { stripeWebhookHandler } from './webhooks/stripe.webhook';
+import { loadAppConfig } from './config/app';
+import { agentsRouter } from './routes/agents';
+import { mcpRouter } from './routes/mcp';
+import { reviewsRouter } from './routes/reviews';
 import { githubWebhookHandler } from './webhooks/github.webhook';
+import { stripeWebhookHandler } from './webhooks/stripe.webhook';
+
+const appConfig = loadAppConfig();
 
 const logger = createLogger({
-  level: process.env.LOG_LEVEL ?? 'info',
-  format: format.combine(
-    format.timestamp(),
-    format.errors({ stack: true }),
-    format.json()
-  ),
+  level: appConfig.logLevel,
+  format: format.combine(format.timestamp(), format.errors({ stack: true }), format.json()),
   transports: [new transports.Console()],
 });
 
-const app: Application = express();
-const PORT = process.env.PORT ?? 3000;
+function requestIdMiddleware(req: Request, res: Response, next: NextFunction): void {
+  const inboundRequestId = req.header('x-request-id');
+  const requestId = inboundRequestId && inboundRequestId.trim() ? inboundRequestId : crypto.randomUUID();
 
-const globalLimiter = rateLimit({
-  windowMs: 60_000,
-  max: 100,
-  standardHeaders: true,
-  legacyHeaders: false,
-  message: { error: 'Too many requests, please try again later.' },
-});
+  res.setHeader('x-request-id', requestId);
+  res.locals.requestId = requestId;
+  next();
+}
 
-const webhookLimiter = rateLimit({
-  windowMs: 60_000,
-  max: 30,
-  standardHeaders: true,
-  legacyHeaders: false,
-  message: { error: 'Too many webhook requests.' },
-});
+function createApp(config = appConfig): Application {
+  const app: Application = express();
 
-app.post(
-  '/webhooks/stripe',
-  webhookLimiter,
-  express.raw({ type: 'application/json', limit: '1mb' }),
-  stripeWebhookHandler
-);
-
-app.post(
-  '/webhooks/github',
-  webhookLimiter,
-  express.raw({ type: 'application/json', limit: '1mb' }),
-  githubWebhookHandler
-);
-
-app.use(globalLimiter);
-app.use(helmet());
-app.use(cors({
-  origin: process.env.CORS_ORIGIN ?? 'http://localhost:3000',
-  credentials: process.env.CORS_CREDENTIALS === 'true',
-}));
-app.use(express.json());
-
-app.get('/health', (_req: Request, res: Response) => {
-  res.json({ status: 'ok', timestamp: new Date().toISOString() });
-});
-
-app.get('/', (_req: Request, res: Response) => {
-  res.json({
-    name: 'openclaw-revenue-engine',
-    version: process.env.npm_package_version ?? '1.0.0',
-    docs: '/health',
-  });
-});
-
-app.use((_req: Request, res: Response) => {
-  res.status(404).json({ error: 'Not Found' });
-});
-
-app.use((err: Error, req: Request, res: Response, _next: NextFunction) => {
-  const status =
-    (err as { status?: number; statusCode?: number }).status ??
-    (err as { status?: number; statusCode?: number }).statusCode ??
-    500;
-
-  logger.error('Unhandled error', {
-    message: err.message,
-    stack: err.stack,
-    path: req.path,
-    method: req.method,
-    status,
+  const globalLimiter = rateLimit({
+    windowMs: config.globalRateLimit.windowMs,
+    max: config.globalRateLimit.max,
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: { error: 'Too many requests, please try again later.' },
   });
 
-  if (status === 413) {
-    res.status(413).json({ error: 'Payload Too Large' });
-    return;
-  }
-  if (status >= 400 && status < 500) {
-    res.status(status).json({ error: err.message || 'Bad Request' });
-    return;
-  }
-  res.status(500).json({ error: 'Internal Server Error' });
-});
+  const webhookLimiter = rateLimit({
+    windowMs: config.webhookRateLimit.windowMs,
+    max: config.webhookRateLimit.max,
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: { error: 'Too many webhook requests.' },
+  });
 
-app.listen(PORT, () => {
-  logger.info(`[openclaw-revenue-engine] Listening on port ${PORT}`);
-});
+  app.disable('x-powered-by');
+  app.use(requestIdMiddleware);
 
-export { logger };
+  app.post(
+    '/webhooks/stripe',
+    webhookLimiter,
+    express.raw({ type: 'application/json', limit: config.jsonBodyLimit }),
+    stripeWebhookHandler
+  );
+
+  app.post(
+    '/webhooks/github',
+    webhookLimiter,
+    express.raw({ type: 'application/json', limit: config.jsonBodyLimit }),
+    githubWebhookHandler
+  );
+
+  app.use(globalLimiter);
+  app.use(helmet());
+  app.use(
+    cors({
+      origin: config.corsOrigin,
+      credentials: config.corsCredentials,
+    })
+  );
+  app.use(express.json({ limit: config.jsonBodyLimit }));
+  app.use('/agents', agentsRouter);
+  app.use('/mcp', mcpRouter);
+  app.use('/reviews', reviewsRouter);
+
+  app.get('/health', (_req: Request, res: Response) => {
+    res.json({
+      status: 'ok',
+      service: config.serviceName,
+      version: config.version,
+      timestamp: new Date().toISOString(),
+    });
+  });
+
+  app.get('/ready', (_req: Request, res: Response) => {
+    res.json({
+      status: 'ready',
+      service: config.serviceName,
+      dependencies: {
+        stripeWebhook: 'lazy-configured',
+        githubWebhook: 'lazy-configured',
+        agents: 'enabled',
+        mcp: 'inventory-only',
+        reviews: 'enabled',
+      },
+    });
+  });
+
+  app.get('/', (_req: Request, res: Response) => {
+    res.json({
+      name: config.serviceName,
+      version: config.version,
+      docs: '/health',
+      readiness: '/ready',
+      agents: '/agents',
+      mcp: '/mcp/servers',
+      reviews: '/reviews',
+    });
+  });
+
+  app.use((_req: Request, res: Response) => {
+    res.status(404).json({ error: 'Not Found', requestId: res.locals.requestId });
+  });
+
+  app.use((err: Error, req: Request, res: Response, _next: NextFunction) => {
+    const status =
+      (err as { status?: number; statusCode?: number }).status ??
+      (err as { status?: number; statusCode?: number }).statusCode ??
+      500;
+
+    logger.error('Unhandled error', {
+      message: err.message,
+      stack: err.stack,
+      path: req.path,
+      method: req.method,
+      status,
+      requestId: res.locals.requestId,
+    });
+
+    if (status === 413) {
+      res.status(413).json({ error: 'Payload Too Large', requestId: res.locals.requestId });
+      return;
+    }
+    if (status >= 400 && status < 500) {
+      res.status(status).json({ error: err.message || 'Bad Request', requestId: res.locals.requestId });
+      return;
+    }
+    res.status(500).json({ error: 'Internal Server Error', requestId: res.locals.requestId });
+  });
+
+  return app;
+}
+
+const app = createApp();
+
+export { appConfig, createApp, logger };
 export default app;

--- a/src/mcp/planner.ts
+++ b/src/mcp/planner.ts
@@ -1,0 +1,48 @@
+import { AgentManifest } from '../agents/types';
+import { loadMcpServers } from './registry';
+import { McpUsagePlan } from './types';
+
+function inferCapability(tool: string): string {
+  if (tool.includes('github') || tool.includes('repo') || tool.includes('pull_request')) return 'repo_read';
+  if (tool.includes('runbook') || tool.includes('policy') || tool.includes('docs')) return 'file_read';
+  if (tool.includes('secret')) return 'secret_read';
+  return 'file_read';
+}
+
+export function planMcpUsage(agent: AgentManifest): McpUsagePlan[] {
+  const servers = loadMcpServers();
+  return agent.allowed_tools.map((tool) => {
+    const capability = inferCapability(tool);
+    const server = servers.find((candidate) => candidate.allowed_capabilities.includes(capability));
+
+    if (!server) {
+      return {
+        server_id: 'none',
+        server_name: 'No compatible MCP server',
+        capability,
+        purpose: `No configured MCP server can satisfy tool ${tool}.`,
+        safe_to_execute: false,
+        blocked_reason: 'missing_capability',
+      };
+    }
+
+    if (server.blocked_capabilities.includes(capability)) {
+      return {
+        server_id: server.id,
+        server_name: server.name,
+        capability,
+        purpose: `Tool ${tool} maps to blocked capability ${capability}.`,
+        safe_to_execute: false,
+        blocked_reason: 'capability_blocked',
+      };
+    }
+
+    return {
+      server_id: server.id,
+      server_name: server.name,
+      capability,
+      purpose: `Use ${server.name} for ${tool} via ${capability}.`,
+      safe_to_execute: true,
+    };
+  });
+}

--- a/src/mcp/registry.ts
+++ b/src/mcp/registry.ts
@@ -1,0 +1,52 @@
+import fs from 'fs';
+import path from 'path';
+
+import { McpInventory, McpServerConfig, McpServerView } from './types';
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+
+function readInventory(inventoryPath = path.join(repoRoot, 'mcp', 'servers.json')): McpInventory {
+  return JSON.parse(fs.readFileSync(inventoryPath, 'utf8')) as McpInventory;
+}
+
+function validateServer(server: McpServerConfig): McpServerConfig {
+  if (!server.id || !server.name || !server.transport || !server.command) {
+    throw new Error('Invalid MCP server config: id, name, transport, and command are required');
+  }
+  if (!Array.isArray(server.allowed_capabilities) || !Array.isArray(server.blocked_capabilities)) {
+    throw new Error(`Invalid MCP server ${server.id}: capabilities must be arrays`);
+  }
+  if (!server.blocked_capabilities.includes('secret_read')) {
+    throw new Error(`Invalid MCP server ${server.id}: secret_read must be blocked`);
+  }
+  return server;
+}
+
+export function loadMcpServers(): McpServerConfig[] {
+  const inventory = readInventory();
+  return inventory.servers.map(validateServer);
+}
+
+export function getMcpServer(serverId: string): McpServerConfig {
+  const server = loadMcpServers().find((item) => item.id === serverId);
+  if (!server) {
+    throw new Error(`Unknown MCP server: ${serverId}`);
+  }
+  return server;
+}
+
+export function viewMcpServers(): McpServerView[] {
+  return loadMcpServers().map((server) => {
+    const missingEnv = server.required_env.filter((key) => !process.env[key]);
+    return {
+      id: server.id,
+      name: server.name,
+      transport: server.transport,
+      allowed_capabilities: server.allowed_capabilities,
+      blocked_capabilities: server.blocked_capabilities,
+      purpose: server.purpose,
+      configured: missingEnv.length === 0,
+      missing_env: missingEnv,
+    };
+  });
+}

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -1,0 +1,36 @@
+export interface McpServerConfig {
+  id: string;
+  name: string;
+  transport: 'stdio' | 'http' | 'sse';
+  command: string;
+  args: string[];
+  required_env: string[];
+  allowed_capabilities: string[];
+  blocked_capabilities: string[];
+  purpose: string;
+}
+
+export interface McpInventory {
+  schema_version: string;
+  servers: McpServerConfig[];
+}
+
+export interface McpServerView {
+  id: string;
+  name: string;
+  transport: McpServerConfig['transport'];
+  allowed_capabilities: string[];
+  blocked_capabilities: string[];
+  purpose: string;
+  configured: boolean;
+  missing_env: string[];
+}
+
+export interface McpUsagePlan {
+  server_id: string;
+  server_name: string;
+  capability: string;
+  purpose: string;
+  safe_to_execute: boolean;
+  blocked_reason?: string;
+}

--- a/src/reviews/reviewQueue.ts
+++ b/src/reviews/reviewQueue.ts
@@ -1,0 +1,79 @@
+import crypto from 'crypto';
+
+import { AgentRunResult } from '../agents/types';
+
+export type ReviewStatus = 'pending' | 'approved' | 'rejected';
+
+export interface ReviewItem {
+  review_id: string;
+  request_id: string;
+  agent_id: string;
+  risk_level: AgentRunResult['risk_level'];
+  status: ReviewStatus;
+  reason: string;
+  findings: AgentRunResult['findings'];
+  recommended_actions: string[];
+  created_at: string;
+  reviewed_at?: string;
+  reviewer?: string;
+  decision_note?: string;
+}
+
+const reviewItems: ReviewItem[] = [];
+
+function buildReason(result: AgentRunResult): string {
+  if (result.risk_level === 'critical') return 'Critical risk requires human review.';
+  if (result.findings.length > 0) return 'Guardrail findings require human review.';
+  return 'Model/profile policy requires human review.';
+}
+
+export function enqueueReview(result: AgentRunResult): ReviewItem | undefined {
+  if (!result.human_review_required) return undefined;
+
+  const existing = reviewItems.find((item) => item.request_id === result.request_id);
+  if (existing) return existing;
+
+  const item: ReviewItem = {
+    review_id: crypto.randomUUID(),
+    request_id: result.request_id,
+    agent_id: result.agent_id,
+    risk_level: result.risk_level,
+    status: 'pending',
+    reason: buildReason(result),
+    findings: result.findings,
+    recommended_actions: result.recommended_actions,
+    created_at: new Date().toISOString(),
+  };
+
+  reviewItems.unshift(item);
+  return item;
+}
+
+export function listReviews(status?: ReviewStatus): ReviewItem[] {
+  return status ? reviewItems.filter((item) => item.status === status) : [...reviewItems];
+}
+
+export function getReview(reviewId: string): ReviewItem | undefined {
+  return reviewItems.find((item) => item.review_id === reviewId);
+}
+
+export function decideReview(
+  reviewId: string,
+  status: Exclude<ReviewStatus, 'pending'>,
+  reviewer: string,
+  decisionNote?: string,
+): ReviewItem {
+  const item = getReview(reviewId);
+  if (!item) throw new Error(`Unknown review_id: ${reviewId}`);
+  if (item.status !== 'pending') throw new Error(`Review ${reviewId} has already been ${item.status}`);
+
+  item.status = status;
+  item.reviewed_at = new Date().toISOString();
+  item.reviewer = reviewer;
+  item.decision_note = decisionNote;
+  return item;
+}
+
+export function clearReviewQueueForTests(): void {
+  reviewItems.length = 0;
+}

--- a/src/routes/agents.ts
+++ b/src/routes/agents.ts
@@ -1,0 +1,58 @@
+import { Router, Request, Response } from 'express';
+import { z } from 'zod';
+
+import { getAgentRun, listAgentRuns, recordAgentRun } from '../agents/auditLog';
+import { listAgents, runAgent } from '../agents/runner';
+import { enqueueReview } from '../reviews/reviewQueue';
+
+const runAgentSchema = z.object({
+  request_id: z.string().optional(),
+  agent_id: z.string().min(1),
+  objective: z.string().min(1),
+  event_summary: z.string().optional(),
+  context: z.record(z.unknown()).optional(),
+});
+
+const agentsRouter = Router();
+
+agentsRouter.get('/', (_req: Request, res: Response) => {
+  res.json({ agents: listAgents() });
+});
+
+agentsRouter.get('/runs', (req: Request, res: Response) => {
+  const rawLimit = typeof req.query.limit === 'string' ? Number.parseInt(req.query.limit, 10) : 50;
+  const limit = Number.isFinite(rawLimit) ? rawLimit : 50;
+  res.json({ runs: listAgentRuns(limit) });
+});
+
+agentsRouter.get('/runs/:requestId', (req: Request, res: Response) => {
+  const record = getAgentRun(req.params.requestId);
+  if (!record) {
+    res.status(404).json({ error: `Unknown request_id: ${req.params.requestId}` });
+    return;
+  }
+  res.json({ run: record });
+});
+
+agentsRouter.post('/run', (req: Request, res: Response) => {
+  const parsed = runAgentSchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({
+      error: 'Invalid agent run payload',
+      details: parsed.error.flatten(),
+    });
+    return;
+  }
+
+  try {
+    const result = runAgent(parsed.data);
+    const audit = recordAgentRun(parsed.data, result);
+    const review = enqueueReview(result);
+    res.json({ ...result, audit, review });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown agent runtime error';
+    res.status(400).json({ error: message });
+  }
+});
+
+export { agentsRouter };

--- a/src/routes/mcp.ts
+++ b/src/routes/mcp.ts
@@ -1,0 +1,33 @@
+import { Router, Request, Response } from 'express';
+
+import { getMcpServer, viewMcpServers } from '../mcp/registry';
+
+const mcpRouter = Router();
+
+mcpRouter.get('/servers', (_req: Request, res: Response) => {
+  res.json({ servers: viewMcpServers() });
+});
+
+mcpRouter.get('/servers/:serverId', (req: Request, res: Response) => {
+  try {
+    const server = getMcpServer(req.params.serverId);
+    const missingEnv = server.required_env.filter((key) => !process.env[key]);
+    res.json({
+      server: {
+        id: server.id,
+        name: server.name,
+        transport: server.transport,
+        allowed_capabilities: server.allowed_capabilities,
+        blocked_capabilities: server.blocked_capabilities,
+        purpose: server.purpose,
+        configured: missingEnv.length === 0,
+        missing_env: missingEnv,
+      },
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown MCP runtime error';
+    res.status(404).json({ error: message });
+  }
+});
+
+export { mcpRouter };

--- a/src/routes/reviews.ts
+++ b/src/routes/reviews.ts
@@ -1,0 +1,68 @@
+import { Router, Request, Response } from 'express';
+import { z } from 'zod';
+
+import { decideReview, getReview, listReviews, ReviewStatus } from '../reviews/reviewQueue';
+
+const decisionSchema = z.object({
+  reviewer: z.string().min(1),
+  decision_note: z.string().optional(),
+});
+
+function parseReviewStatus(value: unknown): ReviewStatus | undefined {
+  if (value === 'pending' || value === 'approved' || value === 'rejected') return value;
+  return undefined;
+}
+
+const reviewsRouter = Router();
+
+reviewsRouter.get('/', (req: Request, res: Response) => {
+  const status = parseReviewStatus(req.query.status);
+  res.json({ reviews: listReviews(status) });
+});
+
+reviewsRouter.get('/pending', (_req: Request, res: Response) => {
+  res.json({ reviews: listReviews('pending') });
+});
+
+reviewsRouter.get('/:reviewId', (req: Request, res: Response) => {
+  const review = getReview(req.params.reviewId);
+  if (!review) {
+    res.status(404).json({ error: `Unknown review_id: ${req.params.reviewId}` });
+    return;
+  }
+  res.json({ review });
+});
+
+reviewsRouter.post('/:reviewId/approve', (req: Request, res: Response) => {
+  const parsed = decisionSchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({ error: 'Invalid review decision payload', details: parsed.error.flatten() });
+    return;
+  }
+
+  try {
+    const review = decideReview(req.params.reviewId, 'approved', parsed.data.reviewer, parsed.data.decision_note);
+    res.json({ review });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown review decision error';
+    res.status(400).json({ error: message });
+  }
+});
+
+reviewsRouter.post('/:reviewId/reject', (req: Request, res: Response) => {
+  const parsed = decisionSchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({ error: 'Invalid review decision payload', details: parsed.error.flatten() });
+    return;
+  }
+
+  try {
+    const review = decideReview(req.params.reviewId, 'rejected', parsed.data.reviewer, parsed.data.decision_note);
+    res.json({ review });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown review decision error';
+    res.status(400).json({ error: message });
+  }
+});
+
+export { reviewsRouter };

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,31 +1,16 @@
-import http from 'http';
+import app, { logger } from './index';
 
-import app, { appConfig, logger } from './index';
+const PORT = process.env.PORT ?? 3000;
 
-const server = http.createServer(app);
+const server = app.listen(PORT, () => {
+  logger.info(`[openclaw-revenue-engine] Listening on port ${PORT}`);
+});
 
-server.listen(appConfig.port, () => {
-  logger.info('[openclaw-revenue-engine] Listening', {
-    port: appConfig.port,
-    env: appConfig.nodeEnv,
-    service: appConfig.serviceName,
-    version: appConfig.version,
+process.on('SIGTERM', () => {
+  logger.info('SIGTERM received; shutting down HTTP server');
+  server.close(() => {
+    logger.info('HTTP server closed');
   });
 });
 
-function shutdown(signal: NodeJS.Signals): void {
-  logger.info('[openclaw-revenue-engine] Shutdown signal received', { signal });
-
-  server.close((error?: Error) => {
-    if (error) {
-      logger.error('[openclaw-revenue-engine] Error during shutdown', { error });
-      process.exit(1);
-    }
-
-    logger.info('[openclaw-revenue-engine] Shutdown complete');
-    process.exit(0);
-  });
-}
-
-process.on('SIGTERM', shutdown);
-process.on('SIGINT', shutdown);
+export default server;

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,31 @@
+import http from 'http';
+
+import app, { appConfig, logger } from './index';
+
+const server = http.createServer(app);
+
+server.listen(appConfig.port, () => {
+  logger.info('[openclaw-revenue-engine] Listening', {
+    port: appConfig.port,
+    env: appConfig.nodeEnv,
+    service: appConfig.serviceName,
+    version: appConfig.version,
+  });
+});
+
+function shutdown(signal: NodeJS.Signals): void {
+  logger.info('[openclaw-revenue-engine] Shutdown signal received', { signal });
+
+  server.close((error?: Error) => {
+    if (error) {
+      logger.error('[openclaw-revenue-engine] Error during shutdown', { error });
+      process.exit(1);
+    }
+
+    logger.info('[openclaw-revenue-engine] Shutdown complete');
+    process.exit(0);
+  });
+}
+
+process.on('SIGTERM', shutdown);
+process.on('SIGINT', shutdown);

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -1,0 +1,21 @@
+import { Response } from 'express';
+
+export function sendBadRequest(res: Response, error: string): void {
+  res.status(400).json({ error });
+}
+
+export function sendUnauthorized(res: Response, error: string): void {
+  res.status(401).json({ error });
+}
+
+export function sendServiceMisconfigured(res: Response, provider: string): void {
+  res.status(500).json({ error: `${provider} webhook is not configured` });
+}
+
+export function sendWebhookProcessingError(res: Response): void {
+  res.status(500).json({ error: 'Internal webhook processing error' });
+}
+
+export function getHeaderValue(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}


### PR DESCRIPTION
## Summary

Supersedes conflicted PR #66 with a clean branch rebased from current `main`.

This PR keeps the core solution code while avoiding the stale merge conflict history:

- repair runtime entrypoints to use `src/server.ts` / `dist/server.js`
- add typed app config and request correlation
- add `/ready` metadata
- add deterministic agent runtime
- add agent run audit log
- add human review queue
- add MCP inventory and safe MCP planning
- expose `/agents`, `/agents/runs`, `/reviews`, and `/mcp/servers` APIs
- add model routing and agent manifests

## Why

PR #66 passed checks but became unmergeable after `main` moved on the same files. This replacement branch starts from current `main`, which removes the conflict without forcing stale history into the branch.

## Validation target

- `npm run type-check`
- `npm test`
- `npm run lint`
- existing CI/security scanners
