### PR TITLE
fix(poll): add requirements.txt and main.py stub to unblock poll workflow

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""
+Moltgate poll worker — stub placeholder for Milestone 5.
+
+This script is invoked by `.github/workflows/poll.yml` every 5 minutes.
+The real implementation will be added when Milestone 4 (Invoice Generation)
+is complete and Moltgate API credentials are provisioned.
+
+Usage:
+    python main.py --once --direct-api --poll-only [--lane LANE_SLUG]
+"""
+import argparse
+import os
+import sys
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Moltgate inbox poll worker")
+    parser.add_argument("--once", action="store_true", help="Run a single poll cycle and exit")
+    parser.add_argument("--direct-api", action="store_true", help="Use Moltgate REST API directly")
+    parser.add_argument("--poll-only", action="store_true", help="Skip processing; only read inbox")
+    parser.add_argument("--lane", default="", help="Lane slug to poll (blank = all)")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    api_key = os.getenv("MOLTGATE_API_KEY", "")
+    base_url = os.getenv("MOLTGATE_BASE_URL", "https://moltgate.com")
+
+    if not api_key:
+        print(
+            "[poll] MOLTGATE_API_KEY is not set — skipping poll (stub mode).",
+            file=sys.stderr,
+        )
+        return 0
+
+    lane_info = f" (lane: {args.lane})" if args.lane else ""
+    print(f"[poll] Would poll {base_url}/inbox{lane_info} — implementation pending (Milestone 5).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/main.py
+++ b/main.py
@@ -27,7 +27,7 @@ def main() -> int:
     args = parse_args()
 
     api_key = os.getenv("MOLTGATE_API_KEY", "")
-    base_url = os.getenv("MOLTGATE_BASE_URL", "https://moltgate.com")
+    base_url = os.getenv("MOLTGATE_BASE_URL", "https://moltgate.com").rstrip("/")
 
     if not api_key:
         print(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+# Python dependencies for the Moltgate poll worker
+# Milestone 5+ — Moltgate Inbox Polling
+anthropic>=0.49.0
+httpx>=0.27.0


### PR DESCRIPTION
## Problem

The `poll.yml` workflow fires every 5 minutes and has been failing at **Set up Python** because `requirements.txt` does not exist in the repo, causing the `cache-dependency-path` resolution to abort.

Additionally, `main.py` is referenced in the poll step but was never scaffolded, so even if setup succeeded the run step would error.

## Changes

| File | Action | Why |
|------|--------|-----|
| `requirements.txt` | Added | Declares `anthropic` + `httpx` — the deps test_api.py already uses; satisfies `setup-python` cache key |
| `main.py` | Added (stub) | Accepts `--once --direct-api --poll-only --lane` flags; exits 0 cleanly if `MOLTGATE_API_KEY` is unset (no-op until Milestone 5) |

## Behavior after merge

- Poll workflow passes `Set up Python` (cache key resolves)
- `python main.py --once --direct-api --poll-only` exits 0 with a skipped-log line when the secret is absent
- Zero external calls until the real poller is implemented in Milestone 5

## Related

- Milestone 5 (Moltgate Inbox Polling) — real implementation goes here
- `test_api.py` — already imports `anthropic`, confirming the dep choice