### PR TITLE
feat(security): add ZAP Zeek Greenbone and Splunk integration contracts

### DIFF
--- a/.github/workflows/zap.yml
+++ b/.github/workflows/zap.yml
@@ -1,0 +1,46 @@
+---
+name: OWASP ZAP Baseline
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_url:
+        description: "Target URL to scan, including protocol"
+        required: true
+        type: string
+      fail_action:
+        description: "Fail workflow when ZAP reports alerts"
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - "true"
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: zap-${{ github.ref }}-${{ inputs.target_url }}
+  cancel-in-progress: false
+
+jobs:
+  baseline:
+    name: OWASP ZAP baseline scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run ZAP baseline scan
+        uses: zaproxy/action-baseline@v0.15.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          target: ${{ inputs.target_url }}
+          docker_name: ghcr.io/zaproxy/zaproxy:stable
+          allow_issue_writing: false
+          fail_action: ${{ inputs.fail_action }}
+          artifact_name: zap-baseline-report
+          cmd_options: "-a -I"

--- a/.github/workflows/zeek.yml
+++ b/.github/workflows/zeek.yml
@@ -1,0 +1,89 @@
+---
+name: Zeek Network Analysis
+
+on:
+  pull_request:
+    branches: ["main"]
+    paths:
+      - ".github/workflows/zeek.yml"
+      - "security/zeek/**"
+      - "security/pcaps/**"
+  push:
+    branches: ["main"]
+    paths:
+      - ".github/workflows/zeek.yml"
+      - "security/zeek/**"
+      - "security/pcaps/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: zeek-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Zeek PCAP analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Locate PCAP fixtures
+        id: pcaps
+        shell: bash
+        run: |
+          mkdir -p security/pcaps zeek-output
+          find security/pcaps -type f \( -name "*.pcap" -o -name "*.pcapng" \) | sort > zeek-output/pcaps.txt
+          if [ -s zeek-output/pcaps.txt ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run Zeek against PCAP fixtures
+        if: steps.pcaps.outputs.found == 'true'
+        shell: bash
+        run: |
+          while IFS= read -r pcap; do
+            base="$(basename "$pcap")"
+            out_dir="zeek-output/${base}"
+            mkdir -p "$out_dir"
+            docker run --rm \
+              -v "$PWD:/workspace" \
+              -w "/workspace/${out_dir}" \
+              zeek/zeek:latest \
+              zeek -r "/workspace/${pcap}" local
+          done < zeek-output/pcaps.txt
+
+      - name: Skip Zeek when no PCAP fixtures exist
+        if: steps.pcaps.outputs.found != 'true'
+        run: echo "No PCAP or PCAPNG fixtures found under security/pcaps; skipping Zeek analysis."
+
+      - name: Summarize Zeek outputs
+        shell: bash
+        run: |
+          {
+            echo "## Zeek Network Analysis"
+            echo
+            if [ -s zeek-output/pcaps.txt ]; then
+              echo "Analyzed packet captures:"
+              sed 's/^/- /' zeek-output/pcaps.txt
+              echo
+              echo "Generated logs:"
+              find zeek-output -type f -name "*.log" | sort | sed 's/^/- /'
+            else
+              echo "No packet captures were analyzed."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload Zeek logs
+        if: steps.pcaps.outputs.found == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: zeek-network-logs
+          path: zeek-output
+          if-no-files-found: ignore

--- a/config/security-integrations.json
+++ b/config/security-integrations.json
@@ -1,0 +1,56 @@
+{
+  "schema_version": "1.0.0",
+  "mode": "operator_review",
+  "integrations": [
+    {
+      "slug": "owasp-zap-baseline",
+      "name": "OWASP ZAP Baseline",
+      "category": "dast",
+      "purpose": "Run passive web application security checks against an operator-supplied target URL.",
+      "workflow": ".github/workflows/zap.yml",
+      "required_secrets": [],
+      "outputs": ["zap_report", "alerts", "operator_review_notes"],
+      "auto_block_release": false,
+      "enabled": true
+    },
+    {
+      "slug": "zeek-network-analysis",
+      "name": "Zeek Network Analysis",
+      "category": "network_security_monitoring",
+      "purpose": "Analyze optional PCAP or PCAPNG fixtures and produce Zeek logs for review.",
+      "workflow": ".github/workflows/zeek.yml",
+      "required_secrets": [],
+      "inputs": ["security/pcaps"],
+      "outputs": ["conn_log", "dns_log", "http_log", "ssl_log", "notice_log"],
+      "auto_block_release": false,
+      "enabled": true
+    },
+    {
+      "slug": "greenbone-community-edition",
+      "name": "Greenbone Community Edition",
+      "category": "vulnerability_assessment",
+      "purpose": "Track planned authenticated and unauthenticated vulnerability assessment operations.",
+      "required_secrets": ["GREENBONE_URL", "GREENBONE_USERNAME", "GREENBONE_PASSWORD"],
+      "outputs": ["scan_summary", "risk_register", "remediation_plan"],
+      "auto_block_release": false,
+      "enabled": false
+    },
+    {
+      "slug": "splunk-log-ingestion",
+      "name": "Splunk Log Ingestion",
+      "category": "siem_observability",
+      "purpose": "Forward curated security and workflow telemetry to Splunk-compatible HTTP Event Collector endpoints.",
+      "required_secrets": ["SPLUNK_HEC_URL", "SPLUNK_HEC_TOKEN"],
+      "outputs": ["security_events", "workflow_events", "agent_audit_events"],
+      "auto_block_release": false,
+      "enabled": false
+    }
+  ],
+  "guardrails": {
+    "manual_dast_targets_only": true,
+    "no_secret_echo": true,
+    "no_credentialed_scans_without_operator_approval": true,
+    "packet_capture_fixtures_only": true,
+    "external_log_forwarding_disabled_by_default": true
+  }
+}

--- a/docs/security-integrations.md
+++ b/docs/security-integrations.md
@@ -1,0 +1,59 @@
+# Security Integrations
+
+This document defines the first security tool integrations for the OpenClaw revenue
+engine. The default posture is conservative: scans are explicit, credentialed
+operations are disabled until configured, and outputs require operator review.
+
+## OWASP ZAP Baseline
+
+The ZAP baseline workflow is manual only. An operator supplies the target URL at
+runtime and decides whether ZAP findings should fail the workflow.
+
+Use this for lightweight web application security checks against a deployed
+staging or preview environment. Do not aim it at third-party systems unless you
+own the target or have written authorization.
+
+## Zeek Network Analysis
+
+The Zeek workflow analyzes packet capture fixtures stored under
+`security/pcaps`. If there are no `.pcap` or `.pcapng` files, the workflow exits
+cleanly and reports that no packet captures were analyzed.
+
+Recommended usage:
+
+- Store only sanitized packet captures.
+- Avoid production customer payloads.
+- Review generated Zeek logs before sharing them externally.
+- Treat DNS, HTTP, TLS, and connection logs as potentially sensitive telemetry.
+
+## Greenbone Community Edition
+
+Greenbone is registered as a planned vulnerability-assessment integration. It is
+disabled by default because authenticated vulnerability scanning needs explicit
+operator approval, target ownership, and credential handling.
+
+Required secret names when enabled:
+
+- `GREENBONE_URL`
+- `GREENBONE_USERNAME`
+- `GREENBONE_PASSWORD`
+
+## Splunk Log Ingestion
+
+Splunk-compatible HTTP Event Collector forwarding is registered but disabled by
+default. The intended use is curated security telemetry, workflow events, and
+agent audit events.
+
+Required secret names when enabled:
+
+- `SPLUNK_HEC_URL`
+- `SPLUNK_HEC_TOKEN`
+
+## Guardrails
+
+- Manual dynamic application security targets only.
+- Packet capture fixtures only.
+- No raw secret echoing.
+- No credentialed scans without operator approval.
+- External log forwarding disabled by default.
+- Findings should become issues, risk-register entries, or operator tasks.


### PR DESCRIPTION
## Summary

Adds security integration scaffolding for application, network, vulnerability-assessment, and SIEM workflows.

## Added

- `.github/workflows/zap.yml` — manual OWASP ZAP baseline workflow with operator-supplied target URL
- `.github/workflows/zeek.yml` — optional Zeek PCAP analysis workflow
- `config/security-integrations.json` — integration registry for ZAP, Zeek, Greenbone Community Edition, and Splunk log ingestion
- `docs/security-integrations.md` — operator guidance and guardrails
- `security/pcaps/.gitkeep` — sanitized packet-capture fixture directory placeholder

## Safety posture

- ZAP is manual only and requires an explicit target URL
- Zeek only analyzes local sanitized PCAP or PCAPNG fixtures
- Greenbone Community Edition is registered but disabled by default
- Splunk log forwarding is registered but disabled by default
- Credentialed scans and external log forwarding require configured secrets and operator approval

## Follow-up candidates

- Add JSON schema validation for `config/security-integrations.json`
- Add Greenbone API export/import workflow once a target environment exists
- Add Splunk HEC forwarding for curated workflow and agent audit events
- Add Zeek log parsing tests using intentionally sanitized sample fixtures
